### PR TITLE
Proper EXICodec process shut down

### DIFF
--- a/iso15118/shared/exificient_exi_codec.py
+++ b/iso15118/shared/exificient_exi_codec.py
@@ -21,7 +21,7 @@ class ExificientEXICodec(IEXICodec):
         logging.getLogger("py4j").setLevel(logging.CRITICAL)
         self.gateway = JavaGateway.launch_gateway(
             classpath=JAR_FILE_PATH,
-            die_on_exit=False,
+            die_on_exit=True,
             javaopts=["--add-opens", "java.base/java.lang=ALL-UNNAMED"],
         )
 


### PR DESCRIPTION
The EXICodec.jar process is now terminated when EVerest shuts down as well

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>