### PR TITLE
Setting the target current to 0A (PrechargeReq)

### DIFF
--- a/iso15118/evcc/states/din_spec_states.py
+++ b/iso15118/evcc/states/din_spec_states.py
@@ -525,7 +525,7 @@ class CableCheck(StateEVCC):
         pre_charge_req = PreChargeReq(
             dc_ev_status=await ev_controller.get_dc_ev_status_dinspec(),
             ev_target_voltage=dc_charge_params.dc_target_voltage,
-            ev_target_current=dc_charge_params.dc_target_current,
+            ev_target_current=0,
         )
         return pre_charge_req
 
@@ -607,7 +607,7 @@ class PreCharge(StateEVCC):
         pre_charge_req = PreChargeReq(
             dc_ev_status=await ev_controller.get_dc_ev_status_dinspec(),
             ev_target_voltage=dc_charge_params.dc_target_voltage,
-            ev_target_current=dc_charge_params.dc_target_current,
+            ev_target_current=0,
         )
         return pre_charge_req
 

--- a/iso15118/evcc/states/iso15118_2_states.py
+++ b/iso15118/evcc/states/iso15118_2_states.py
@@ -1308,7 +1308,7 @@ class CableCheck(StateEVCC):
         pre_charge_req = PreChargeReq(
             dc_ev_status=await self.comm_session.ev_controller.get_dc_ev_status(),
             ev_target_voltage=charge_params.dc_target_voltage,
-            ev_target_current=charge_params.dc_target_current,
+            ev_target_current=0,
         )
         return pre_charge_req
 
@@ -1385,7 +1385,7 @@ class PreCharge(StateEVCC):
         pre_charge_req = PreChargeReq(
             dc_ev_status=await self.comm_session.ev_controller.get_dc_ev_status(),
             ev_target_voltage=charge_params.dc_target_voltage,
-            ev_target_current=charge_params.dc_target_current,
+            ev_target_current=0,
         )
         return pre_charge_req
 


### PR DESCRIPTION
According to the standard, the car should only request under 2A in precharge.