### PR TITLE
Now Josev runs again under Python versions <3.12

### DIFF
--- a/iso15118/evcc/controller/simulator.py
+++ b/iso15118/evcc/controller/simulator.py
@@ -230,8 +230,7 @@ class SimEVController(EVControllerInterface):
             # The check digit (last character) is not a correctly computed one
             return "WMIV1234567890ABCDEX"
         else:
-            logger.error(f"Invalid protocol '{
-                         protocol}', can't determine EVCCID")
+            logger.error(f"Invalid protocol '{protocol}', can't determine EVCCID")
             raise InvalidProtocolError
 
     async def get_energy_transfer_mode(
@@ -373,8 +372,7 @@ class SimEVController(EVControllerInterface):
         else:
             # TODO Implement the remaining energy transer services
             logger.error(
-                f"Energy transfer service {
-                    selected_service.service} not supported"
+                f"Energy transfer service {selected_service.service} not supported"
             )
             raise NotImplementedError
 

--- a/iso15118/shared/comm_session.py
+++ b/iso15118/shared/comm_session.py
@@ -242,8 +242,7 @@ class SessionStateMachine(ABC):
             await self.current_state.process_message(decoded_message, v2gtp_msg.payload)
         except MessageProcessingError as exc:
             logger.exception(
-                f"{exc.__class__.__name__} while processing " f"{
-                    exc.message_name}"
+                f"{exc.__class__.__name__} while processing " f"{exc.message_name}"
             )
             raise exc
         except FaultyStateImplementationError as exc:
@@ -421,8 +420,7 @@ class V2GCommunicationSession(SessionStateMachine):
             await self.writer.wait_closed()
         except (asyncio.TimeoutError, ConnectionResetError) as exc:
             logger.info(str(exc))
-        logger.info("TCP connection closed to peer with address " f"{
-                    self.peer_name}")
+        logger.info("TCP connection closed to peer with address " f"{self.peer_name}")
 
     async def send(self, message: V2GTPMessage):
         """
@@ -486,8 +484,7 @@ class V2GCommunicationSession(SessionStateMachine):
                             f"while waiting for SupportedAppProtocolReq"
                         )
                 else:
-                    error_msg = f"{
-                        exc.__class__.__name__} occurred. {str(exc)}"
+                    error_msg = f"{exc.__class__.__name__} occurred. {str(exc)}"
 
                 self.stop_reason = StopNotification(
                     False, error_msg, self.peer_name)


### PR DESCRIPTION
Due to a wrong code formatting Josev only ran with Python version 3.12. With this fix Josev runs again with Python versions lower than 3.12.