### PR TITLE
Removing pydantic check for price_level_schedule and absolute_price_schedule

### DIFF
--- a/iso15118/shared/messages/iso15118_20/common_messages.py
+++ b/iso15118/shared/messages/iso15118_20/common_messages.py
@@ -710,30 +710,6 @@ class ChargingSchedule(BaseModel):
         None, alias="AbsolutePriceSchedule"
     )
 
-    @root_validator(pre=True)
-    def either_price_levels_or_absolute_prices(cls, values):
-        """
-        Either price_level_schedule or absolute_price_schedule must be set,
-        depending on whether abstract price levels or absolute prices are used
-        to indicate costs for the charging session.
-
-        Pydantic validators are "class methods",
-        see https://pydantic-docs.helpmanual.io/usage/validators/
-        """
-        # pylint: disable=no-self-argument
-        # pylint: disable=no-self-use
-        if one_field_must_be_set(
-            [
-                "price_level_schedule",
-                "PriceLevelSchedule",
-                "absolute_price_schedule",
-                "AbsolutePriceSchedule",
-            ],
-            values,
-            True,
-        ):
-            return values
-
 
 class DischargingSchedule(BaseModel):
     """See section 8.3.5.3.40 in ISO 15118-20"""
@@ -746,30 +722,6 @@ class DischargingSchedule(BaseModel):
 
     # TODO Need to add a root validator to check if power schedule entries are negative
     #      for discharging (also heck other discharging fields in other types)
-
-    @root_validator(pre=True)
-    def either_price_levels_or_absolute_prices(cls, values):
-        """
-        Either price_level_schedule or absolute_price_schedule must be set,
-        depending on abstract price levels or absolute prices are used to
-        indicate costs for the charging session.
-
-        Pydantic validators are "class methods",
-        see https://pydantic-docs.helpmanual.io/usage/validators/
-        """
-        # pylint: disable=no-self-argument
-        # pylint: disable=no-self-use
-        if one_field_must_be_set(
-            [
-                "price_level_schedule",
-                "PriceLevelSchedule",
-                "absolute_price_schedule",
-                "AbsolutePriceSchedule",
-            ],
-            values,
-            True,
-        ):
-            return values
 
 
 class ScheduleTuple(BaseModel):

--- a/iso15118/shared/messages/iso15118_20/common_messages.py
+++ b/iso15118/shared/messages/iso15118_20/common_messages.py
@@ -44,7 +44,10 @@ from iso15118.shared.messages.iso15118_20.common_types import (
     V2GRequest,
     V2GResponse,
 )
-from iso15118.shared.validators import one_field_must_be_set
+from iso15118.shared.validators import (
+    one_field_must_be_set,
+    one_field_must_be_set_or_none,
+)
 
 
 class ECDHCurve(str, Enum):
@@ -710,6 +713,28 @@ class ChargingSchedule(BaseModel):
         None, alias="AbsolutePriceSchedule"
     )
 
+    @root_validator(pre=True)
+    def either_price_levels_or_absolute_prices(cls, values):
+        """
+        Either price_level_schedule, absolute_price_schedule or none must be set,
+        depending on whether abstract price levels or absolute prices are used
+        to indicate costs for the charging session.
+        Pydantic validators are "class methods",
+        see https://pydantic-docs.helpmanual.io/usage/validators/
+        """
+        # pylint: disable=no-self-argument
+        # pylint: disable=no-self-use
+        if one_field_must_be_set_or_none(
+            [
+                "price_level_schedule",
+                "PriceLevelSchedule",
+                "absolute_price_schedule",
+                "AbsolutePriceSchedule",
+            ],
+            values,
+        ):
+            return values
+
 
 class DischargingSchedule(BaseModel):
     """See section 8.3.5.3.40 in ISO 15118-20"""
@@ -722,6 +747,28 @@ class DischargingSchedule(BaseModel):
 
     # TODO Need to add a root validator to check if power schedule entries are negative
     #      for discharging (also heck other discharging fields in other types)
+
+    @root_validator(pre=True)
+    def either_price_levels_or_absolute_prices(cls, values):
+        """
+        Either price_level_schedule, absolute_price_schedule or none must be set,
+        depending on whether abstract price levels or absolute prices are used
+        to indicate costs for the charging session.
+        Pydantic validators are "class methods",
+        see https://pydantic-docs.helpmanual.io/usage/validators/
+        """
+        # pylint: disable=no-self-argument
+        # pylint: disable=no-self-use
+        if one_field_must_be_set_or_none(
+            [
+                "price_level_schedule",
+                "PriceLevelSchedule",
+                "absolute_price_schedule",
+                "AbsolutePriceSchedule",
+            ],
+            values,
+        ):
+            return values
 
 
 class ScheduleTuple(BaseModel):

--- a/iso15118/shared/validators.py
+++ b/iso15118/shared/validators.py
@@ -78,3 +78,36 @@ def one_field_must_be_set(
         )
 
     return True
+
+
+def one_field_must_be_set_or_none(field_options: List[str], values: dict) -> bool:
+    """
+    In several messages, there is the option to choose one of two or more
+    possible fields, where all fields are defined as optional in the
+    corresponding model but exactly one or none of them needs to be set.
+
+    Args:
+        field_options: List of optional field names and aliases of a model.
+                       For each field, we need both the field name and the alias
+                       because when instantiating a pydantic model, we use the
+                       pythonic field names, but when de-serialising the model
+                       through JSON via the EXI codec, we use the aliases.
+        values: The dict with the model's fields
+    """
+    set_fields: List = []
+    for field_name in field_options:
+        field = values.get(f"{field_name}")
+        # Important to not check for "if field" instead of "if field is not None" to
+        # avoid situations in which field evaluates to 0 (which equals to False)
+        if field is not None:
+            set_fields.append(field)
+
+    if len(set_fields) > 1:
+        raise ValueError(
+            f"Exactly one field must be set but {len(set_fields)} "
+            "are set instead. "
+            f"\nSet fields: {set_fields}"
+            f"\nField options: {field_options}"
+        )
+
+    return True

--- a/iso15118/shared/validators.py
+++ b/iso15118/shared/validators.py
@@ -94,13 +94,8 @@ def one_field_must_be_set_or_none(field_options: List[str], values: dict) -> boo
                        through JSON via the EXI codec, we use the aliases.
         values: The dict with the model's fields
     """
-    set_fields: List = []
-    for field_name in field_options:
-        field = values.get(f"{field_name}")
-        # Important to not check for "if field" instead of "if field is not None" to
-        # avoid situations in which field evaluates to 0 (which equals to False)
-        if field is not None:
-            set_fields.append(field)
+    field_values = [values.get(f"{field_name}") for field_name in field_options]
+    set_fields = [x for x in field_values if x is not None]
 
     if len(set_fields) > 1:
         raise ValueError(


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
According the iso15118-20 schema file the charger can either send no price information, absolute or price_level

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

