### PR TITLE
Refactor TLS 1.3 support for D20 Ev side

### DIFF
--- a/iso15118/shared/pki/configs/vehicleLeafCert.cnf
+++ b/iso15118/shared/pki/configs/vehicleLeafCert.cnf
@@ -1,0 +1,15 @@
+[req]
+prompt 					= no
+distinguished_name		= ca_dn
+
+[ca_dn]
+commonName				= WMIV1234567890ABCDEX
+organizationName		= Pionix
+countryName				= DE
+domainComponent			= OEM
+
+[ext]
+basicConstraints		= critical,CA:false
+keyUsage				= critical,digitalSignature,keyAgreement
+subjectKeyIdentifier	= hash
+

--- a/iso15118/shared/pki/configs/vehicleSubCA1Cert.cnf
+++ b/iso15118/shared/pki/configs/vehicleSubCA1Cert.cnf
@@ -1,0 +1,15 @@
+[req]
+prompt 					= no
+distinguished_name		= ca_dn
+
+[ca_dn]
+commonName				= VehicleSubCA1
+organizationName		= Pionix
+countryName				= DE
+domainComponent			= OEM
+
+[ext]
+basicConstraints		= critical,CA:true,pathlen:1
+keyUsage				= critical,keyCertSign,cRLSign
+subjectKeyIdentifier	= hash
+

--- a/iso15118/shared/pki/configs/vehicleSubCA2Cert.cnf
+++ b/iso15118/shared/pki/configs/vehicleSubCA2Cert.cnf
@@ -1,0 +1,15 @@
+[req]
+prompt 					= no
+distinguished_name		= ca_dn
+
+[ca_dn]
+commonName				= VehicleSubCA2
+organizationName		= Pionix
+countryName				= DE
+domainComponent			= OEM
+
+[ext]
+basicConstraints		= critical,CA:true,pathlen:0
+keyUsage				= critical,keyCertSign,cRLSign
+subjectKeyIdentifier	= hash
+

--- a/iso15118/shared/pki/create_certs.sh
+++ b/iso15118/shared/pki/create_certs.sh
@@ -30,6 +30,9 @@ VALIDITY_OEM_LEAF_CERT=1460
 VALIDITY_OEM_SUBCA2_CERT=1460
 VALIDITY_OEM_SUBCA1_CERT=1460
 VALIDITY_OEM_ROOT_CERT=3650
+VALIDITY_VEHICLE_SUBCA1_CERT=1460
+VALIDITY_VEHICLE_SUBCA2_CERT=365
+VALIDITY_VEHICLE_LEAF_CERT=60
 VALIDITY_CPS_LEAF_CERT=90
 VALIDITY_CPS_SUBCA2_CERT=730
 VALIDITY_CPS_SUBCA1_CERT=1460
@@ -158,6 +161,7 @@ CA_CSMS_PATH=$CERT_PATH/ca/csms
 CA_CPS_PATH=$CERT_PATH/ca/cps
 CA_CSO_PATH=$CERT_PATH/ca/cso
 CA_OEM_PATH=$CERT_PATH/ca/oem
+CA_VEHICLE_PATH=$CERT_PATH/ca/vehicle
 CA_MO_PATH=$CERT_PATH/ca/mo
 CA_V2G_PATH=$CERT_PATH/ca/v2g
 
@@ -165,6 +169,7 @@ CLIENT_CSMS_PATH=$CERT_PATH/client/csms
 CLIENT_CPS_PATH=$CERT_PATH/client/cps
 CLIENT_CSO_PATH=$CERT_PATH/client/cso
 CLIENT_OEM_PATH=$CERT_PATH/client/oem
+CLIENT_VEHICLE_PATH=$CERT_PATH/client/vehicle
 CLIENT_MO_PATH=$CERT_PATH/client/mo
 CLIENT_V2G_PATH=$CERT_PATH/client/v2g
 
@@ -174,12 +179,14 @@ mkdir -p $CA_CSMS_PATH
 mkdir -p $CA_CPS_PATH
 mkdir -p $CA_CSO_PATH
 mkdir -p $CA_OEM_PATH
+mkdir -p $CA_VEHICLE_PATH
 mkdir -p $CA_MO_PATH
 mkdir -p $CA_V2G_PATH
 mkdir -p $CLIENT_CSMS_PATH
 mkdir -p $CLIENT_CPS_PATH
 mkdir -p $CLIENT_CSO_PATH
 mkdir -p $CLIENT_OEM_PATH
+mkdir -p $CLIENT_VEHICLE_PATH
 mkdir -p $CLIENT_MO_PATH
 mkdir -p $CLIENT_V2G_PATH
 
@@ -356,7 +363,32 @@ cat $CA_CPS_PATH/CPS_SUB_CA2.pem $CA_CPS_PATH/CPS_SUB_CA1.pem > $CA_CPS_PATH/INT
 openssl pkcs12 -export -inkey $CLIENT_CPS_PATH/CPS_LEAF.key -in $CLIENT_CPS_PATH/CPS_LEAF.pem -certfile $CA_CPS_PATH/INTERMEDIATE_CPS_CA_CERTS.pem $SYMMETRIC_CIPHER_PKCS12 -passin pass:$password -passout pass:$password -name cps_leaf_cert -out $CLIENT_CPS_PATH/CPS_CERT_CHAIN.p12
 
 
-# 16) Finally we need to convert the certificates from PEM format to DER format
+# 16) Create an intermediate vehicle sub-CA 1 certificate which is directly signed
+#    by the V2GRootCA certificate
+# ---------------------------------------------------------------------------
+openssl ecparam -genkey -name $EC_CURVE | openssl ec $SYMMETRIC_CIPHER -passout pass:$password -out $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA1.key
+openssl req -new -key $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA1.key -passin pass:$password -config configs/vehicleSubCA1Cert.cnf -out $CSR_PATH/VEHICLE_SUB_CA1.csr
+openssl x509 -req -in $CSR_PATH/VEHICLE_SUB_CA1.csr -extfile configs/vehicleSubCA1Cert.cnf -extensions ext -CA $CA_V2G_PATH/V2G_ROOT_CA.pem -CAkey $CLIENT_V2G_PATH/V2G_ROOT_CA.key -passin pass:$password -set_serial 12360 -out $CA_VEHICLE_PATH/VEHICLE_SUB_CA1.pem -days $VALIDITY_VEHICLE_SUBCA1_CERT
+
+
+# 17) Create a second intermediate vehicle sub-CA certificate (sub-CA 2) just the way
+#    the previous intermedia certificate was created, which is directly signed
+#    by the VEHICLE_SUB_CA1
+openssl ecparam -genkey -name $EC_CURVE | openssl ec $SYMMETRIC_CIPHER -passout pass:$password -out $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA2.key
+openssl req -new -key $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA2.key -passin pass:$password -config configs/vehicleSubCA2Cert.cnf -out $CSR_PATH/VEHICLE_SUB_CA2.csr
+openssl x509 -req -in $CSR_PATH/VEHICLE_SUB_CA2.csr -extfile configs/vehicleSubCA2Cert.cnf -extensions ext -CA $CA_VEHICLE_PATH/VEHICLE_SUB_CA1.pem -CAkey $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA1.key -passin pass:$password -set_serial 12361 -days $VALIDITY_VEHICLE_SUBCA2_CERT -out $CA_VEHICLE_PATH/VEHICLE_SUB_CA2.pem
+
+
+# 18) Create an vehicle certificate, which is the leaf certificate belonging to
+#    the electric vehicle that authenticates itself to the SECC during a TLS
+#    handshake, signed by VEHICLE_SUB_CA2
+openssl ecparam -genkey -name $EC_CURVE | openssl ec $SYMMETRIC_CIPHER -passout pass:$password -out $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.key
+openssl req -new -key $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.key -passin pass:$password -config configs/vehicleLeafCert.cnf -out $CSR_PATH/VEHICLE_LEAF.csr
+openssl x509 -req -in $CSR_PATH/VEHICLE_LEAF.csr -extfile configs/vehicleLeafCert.cnf -extensions ext -CA $CA_VEHICLE_PATH/VEHICLE_SUB_CA2.pem -CAkey $CLIENT_VEHICLE_PATH/VEHICLE_SUB_CA2.key -passin pass:$password -set_serial 12362 -days $VALIDITY_VEHICLE_LEAF_CERT -out $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.pem
+
+cat $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.pem $CA_VEHICLE_PATH/VEHICLE_SUB_CA2.pem $CA_VEHICLE_PATH/VEHICLE_SUB_CA1.pem > $CLIENT_VEHICLE_PATH/VEHICLE_CERT_CHAIN.pem
+
+# 19) Finally we need to convert the certificates from PEM format to DER format
 #     (PEM is the default format, but ISO 15118 only allows DER format)
 openssl x509 -inform PEM -in $CA_V2G_PATH/V2G_ROOT_CA.pem -outform DER -out $CA_V2G_PATH/V2G_ROOT_CA.der
 openssl x509 -inform PEM -in $CA_CPS_PATH/CPS_SUB_CA1.pem -outform DER -out $CA_CPS_PATH/CPS_SUB_CA1.der
@@ -373,6 +405,9 @@ openssl x509 -inform PEM -in $CA_MO_PATH/MO_ROOT_CA.pem  -outform DER -out $CA_M
 openssl x509 -inform PEM -in $CA_MO_PATH/MO_SUB_CA1.pem  -outform DER -out $CA_MO_PATH/MO_SUB_CA1.der
 openssl x509 -inform PEM -in $CA_MO_PATH/MO_SUB_CA2.pem  -outform DER -out $CA_MO_PATH/MO_SUB_CA2.der
 openssl x509 -inform PEM -in $CLIENT_MO_PATH/MO_LEAF.pem -outform DER -out $CLIENT_MO_PATH/MO_LEAF.der
+openssl x509 -inform PEM -in $CA_VEHICLE_PATH/VEHICLE_SUB_CA1.pem -outform DER -out $CA_VEHICLE_PATH/VEHICLE_SUB_CA1.der
+openssl x509 -inform PEM -in $CA_VEHICLE_PATH/VEHICLE_SUB_CA2.pem -outform DER -out $CA_VEHICLE_PATH/VEHICLE_SUB_CA2.der
+openssl x509 -inform PEM -in $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.pem  -outform DER -out $CLIENT_VEHICLE_PATH/VEHICLE_LEAF.der
 # Since the intermediate certificates need to be in PEM format when putting them
 # in a PKCS12 container and the resulting PKCS12 file is a binary format, it
 # might be sufficient. Otherwise, I have currently no idea how to covert the
@@ -380,13 +415,13 @@ openssl x509 -inform PEM -in $CLIENT_MO_PATH/MO_LEAF.pem -outform DER -out $CLIE
 # the PKCS12 container.
 
 
-# 17) In case you want the private keys in PKCS#8 file format and DER encoded,
+# 20) In case you want the private keys in PKCS#8 file format and DER encoded,
 #     use this command.
 openssl pkcs8 -topk8 -in $CLIENT_MO_PATH/MO_SUB_CA2.key -inform PEM -passin pass:$password -passout pass:$password -outform DER -out $CLIENT_MO_PATH/MO_SUB_CA2.pkcs8.der -v1 PBE-SHA1-3DES
 
 # Side notes for OCSP stapling in Java: see http://openjdk.java.net/jeps/249
 
-# 18) Place all passwords to generated private keys in separate text files.
+# 21) Place all passwords to generated private keys in separate text files.
 #     In this script, even though we use a single password for all certificates,
 #     certificates from a different source could have been generated with a different
 #     passphrase/passkey/password altogether. Leave them empty if no password is required.
@@ -396,6 +431,7 @@ echo $password > $CLIENT_MO_PATH/MO_LEAF_PASSWORD.txt
 echo $password > $CLIENT_CPS_PATH/CPS_LEAF_PASSWORD.txt
 echo $password > $CLIENT_MO_PATH/MO_SUB_CA2_LEAF_PASSWORD.txt
 echo $password > $CLIENT_V2G_PATH/V2G_ROOT_CA_PASSWORD.txt
+echo $password > $CLIENT_VEHICLE_PATH/VEHICLE_LEAF_PASSWORD.txt
 
 # assume CSO and CSMS are same authority
 cp -r $CA_CSMS_PATH/* $CA_CSO_PATH
@@ -510,10 +546,12 @@ then
     mkdir -p $everest_core_path/config/certs/ca/v2g/ && cp $CA_V2G_PATH/* $everest_core_path/config/certs/ca/v2g/
     mkdir -p $everest_core_path/config/certs/ca/cps/ && cp $CA_CPS_PATH/* $everest_core_path/config/certs/ca/cps/
     mkdir -p $everest_core_path/config/certs/ca/oem/ && cp $CA_OEM_PATH/* $everest_core_path/config/certs/ca/oem/
+    mkdir -p $everest_core_path/config/certs/ca/vehicle && cp $CA_VEHICLE_PATH/* $everest_core_path/config/certs/ca/vehicle
 
     mkdir -p $everest_core_path/config/certs/client/cps && cp $CLIENT_CPS_PATH/* $everest_core_path/config/certs/client/cps
     mkdir -p $everest_core_path/config/certs/client/csms && cp $CLIENT_CSMS_PATH/* $everest_core_path/config/certs/client/csms
     mkdir -p $everest_core_path/config/certs/client/cso && cp $CLIENT_CSO_PATH/* $everest_core_path/config/certs/client/cso
     mkdir -p $everest_core_path/config/certs/client/oem && cp $CLIENT_OEM_PATH/* $everest_core_path/config/certs/client/oem
     mkdir -p $everest_core_path/config/certs/client/mo && cp $CLIENT_MO_PATH/* $everest_core_path/config/certs/client/mo
+    mkdir -p $everest_core_path/config/certs/client/vehicle && cp $CLIENT_VEHICLE_PATH/* $everest_core_path/config/certs/client/vehicle
 fi

--- a/iso15118/shared/security.py
+++ b/iso15118/shared/security.py
@@ -81,7 +81,7 @@ from iso15118.shared.messages.xmldsig import (
     Transform,
     Transforms,
 )
-from iso15118.shared.settings import enable_tls_1_3, get_PKI_PATH
+from iso15118.shared.settings import enabled_tls_1_3, get_PKI_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
          as well as read the password.
     """
 
-    if enable_tls_1_3:
+    if enabled_tls_1_3:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     else:
         # Specifying protocol as `PROTOCOL_TLS` does best effort.
@@ -164,7 +164,7 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
             logger.exception(exc)
             return None
 
-        if enable_tls_1_3:
+        if enabled_tls_1_3:
             # In 15118-20 we should also verify EVCC's certificate chain.
             # The spec however says TLS 1.3 should also support 15118-2
             # (Table 5 in V2G20 specification)
@@ -187,9 +187,7 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
         ssl_context.verify_mode = VerifyMode.CERT_REQUIRED
         ssl_context.set_ciphers(ciphersuites)
 
-        print(f"security enable_tls_1_3: {enable_tls_1_3}")
-
-        if enable_tls_1_3:
+        if enabled_tls_1_3:
             try:
                 ssl_context.load_cert_chain(
                     certfile=os.path.join(get_PKI_PATH(), CertPath.VEHICLE_CERT_CHAIN_PEM),

--- a/iso15118/shared/security.py
+++ b/iso15118/shared/security.py
@@ -81,7 +81,7 @@ from iso15118.shared.messages.xmldsig import (
     Transform,
     Transforms,
 )
-from iso15118.shared.settings import ENABLE_TLS_1_3, get_PKI_PATH
+from iso15118.shared.settings import enable_tls_1_3, get_PKI_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
          as well as read the password.
     """
 
-    if ENABLE_TLS_1_3:
+    if enable_tls_1_3:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     else:
         # Specifying protocol as `PROTOCOL_TLS` does best effort.
@@ -164,14 +164,14 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
             logger.exception(exc)
             return None
 
-        if ENABLE_TLS_1_3:
+        if enable_tls_1_3:
             # In 15118-20 we should also verify EVCC's certificate chain.
             # The spec however says TLS 1.3 should also support 15118-2
             # (Table 5 in V2G20 specification)
             # Marc/André - this suggests we will need mutual auth 15118-2 if
             # TLS1.3 is enabled.
             ssl_context.load_verify_locations(
-                cafile=os.path.join(get_PKI_PATH(), CertPath.OEM_ROOT_PEM))
+                cafile=os.path.join(get_PKI_PATH(), CertPath.VEHICLE_ROOT_PEM))
             ssl_context.verify_mode = VerifyMode.CERT_REQUIRED
         else:
             # In ISO 15118-2, we only verify the SECC's certificates
@@ -187,24 +187,26 @@ def get_ssl_context(server_side: bool, ciphersuites: str = None) -> Optional[SSL
         ssl_context.verify_mode = VerifyMode.CERT_REQUIRED
         ssl_context.set_ciphers(ciphersuites)
 
-        if ENABLE_TLS_1_3:
+        print(f"security enable_tls_1_3: {enable_tls_1_3}")
+
+        if enable_tls_1_3:
             try:
                 ssl_context.load_cert_chain(
-                    certfile=os.path.join(get_PKI_PATH(), CertPath.OEM_CERT_CHAIN_PEM),
-                    keyfile=os.path.join(get_PKI_PATH(), KeyPath.OEM_LEAF_PEM),
+                    certfile=os.path.join(get_PKI_PATH(), CertPath.VEHICLE_CERT_CHAIN_PEM),
+                    keyfile=os.path.join(get_PKI_PATH(), KeyPath.VEHICLE_LEAF_PEM),
                     password=load_priv_key_pass(os.path.join(
-                        get_PKI_PATH(), KeyPasswordPath.OEM_LEAF_KEY_PASSWORD)),
+                        get_PKI_PATH(), KeyPasswordPath.VEHICLE_LEAF_KEY_PASSWORD)),
                 )
             except SSLError:
                 logger.exception(
-                    "SSLError, can't load OEM certificate chain for SSL "
+                    "SSLError, can't load Vehicle certificate chain for SSL "
                     "context. Private key (keyfile) probably doesn't "
                     "match certificate (certfile) or password for "
                     "private is key invalid. Returning None instead."
                 )
                 return None
             except FileNotFoundError:
-                logger.exception("Can't find OEM certfile or keyfile for SSL context")
+                logger.exception("Can't find Vehicle certfile or keyfile for SSL context")
                 return None
             except Exception as exc:
                 logger.exception(exc)
@@ -1502,6 +1504,14 @@ class CertPath(str, Enum):
     OEM_ROOT_PEM = "ca/oem/OEM_ROOT_CA.pem"
     OEM_CERT_CHAIN_PEM = "client/oem/OEM_CERT_CHAIN.pem"
 
+    # Vehicle
+    VEHICLE_LEAF_DER = "client/vehicle/VEHICLE_LEAF.der"
+    VEHICLE_SUB_CA2_DER = "ca/vehicle/VEHICLE_SUB_CA2.der"
+    VEHICLE_SUB_CA1_DER = "ca/vehicle/VEHICLE_SUB_CA1.der"
+    VEHICLE_ROOT_DER = "ca/v2g/V2G_ROOT_CA.der"
+    VEHICLE_ROOT_PEM = "ca/v2g/V2G_ROOT_CA.pem"
+    VEHICLE_CERT_CHAIN_PEM = "client/vehicle/VEHICLE_CERT_CHAIN.pem"
+
 
 class KeyPath(str, Enum):
     """
@@ -1536,6 +1546,12 @@ class KeyPath(str, Enum):
     OEM_SUB_CA1_PEM = "client/oem/OEM_SUB_CA1.key"
     OEM_ROOT_PEM = "client/oem/OEM_ROOT_CA.key"
 
+    # Vehicle
+    VEHICLE_LEAF_PEM = "client/vehicle/VEHICLE_LEAF.key"
+    VEHICLE_SUB_CA2_PEM = "client/vehicle/VEHICLE_SUB_CA2.key"
+    VEHICLE_SUB_CA1_PEM = "client/vehicle/VEHICLE_SUB_CA1.key"
+    VEHICLE_ROOT_PEM = "client/v2g/V2G_ROOT_CA.key"
+
 
 class KeyPasswordPath(str, Enum):
     """
@@ -1551,3 +1567,4 @@ class KeyPasswordPath(str, Enum):
     CONTRACT_LEAF_KEY_PASSWORD = "client/mo/MO_LEAF_PASSWORD.txt"
     CPS_LEAF_KEY_PASSWORD = "client/cps/CPS_LEAF_PASSWORD.txt"
     MO_SUB_CA2_PASSWORD = "client/cso/CPO_SUB_CA2_PASSWORD.txt"
+    VEHICLE_LEAF_KEY_PASSWORD = "client/vehicle/VEHICLE_LEAF_PASSWORD.txt"

--- a/iso15118/shared/settings.py
+++ b/iso15118/shared/settings.py
@@ -20,11 +20,11 @@ MESSAGE_LOG_EXI = False
 
 V20_EVSE_SERVICES_CONFIG = SHARED_CWD + "/examples/secc/15118_20/service_config.json"
 
-enable_tls_1_3 = False
+enabled_tls_1_3 = False
 
 def enable_tls_1_3() -> None:
-    global enable_tls_1_3
-    enable_tls_1_3 = True
+    global enabled_tls_1_3
+    enabled_tls_1_3 = True
 
 shared_settings = None
 

--- a/iso15118/shared/settings.py
+++ b/iso15118/shared/settings.py
@@ -20,7 +20,12 @@ MESSAGE_LOG_EXI = False
 
 V20_EVSE_SERVICES_CONFIG = SHARED_CWD + "/examples/secc/15118_20/service_config.json"
 
-ENABLE_TLS_1_3 = False
+enable_tls_1_3 = False
+
+def enable_tls_1_3() -> None:
+    global enable_tls_1_3
+    enable_tls_1_3 = True
+
 shared_settings = None
 
 ignoring_value_range = False


### PR DESCRIPTION
## Describe your changes
- Adding vehicle certs for d20 tls 1.3 support
- Changed ENABLE_TLS_1_3

## Issue ticket number and link
Missing vehicle leaf + sub cas for tls 1.3 handshake. Missing option to enable tls 1.3

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements