### PR TITLE
feat: prioritize energy services

### DIFF
--- a/iso15118/evcc/controller/simulator.py
+++ b/iso15118/evcc/controller/simulator.py
@@ -251,11 +251,22 @@ class SimEVController(EVControllerInterface):
         self, services: List[MatchedService]
     ) -> SelectedEnergyService:
         """Overrides EVControllerInterface.select_energy_service_v20()."""
-        top_of_list: MatchedService = services[0]
+        prioritized_supported_list = self.config.supported_energy_services
+
+        # find first match that is one of the first in the supported list
+        selected_match = None
+        for service in prioritized_supported_list:
+            for matched_service in services:
+                if service == matched_service.service:
+                    selected_match = matched_service
+                    break
+            if selected_match is not None:
+                break
+
         selected_service = SelectedEnergyService(
-            service=top_of_list.service,
-            is_free=top_of_list.is_free,
-            parameter_set=top_of_list.parameter_sets[0],
+            service=selected_match.service,
+            is_free=selected_match.is_free,
+            parameter_set=selected_match.parameter_sets[0],
         )
         return selected_service
 

--- a/iso15118/shared/utils.py
+++ b/iso15118/shared/utils.py
@@ -15,8 +15,14 @@ logger = logging.getLogger(__name__)
 def _format_list(read_settings: List[str]) -> List[str]:
     read_settings = list(filter(None, read_settings))
     read_settings = [setting.strip().upper() for setting in read_settings]
-    read_settings_set = set(read_settings)
-    return [setting for setting in read_settings if setting in read_settings_set]
+
+    output = []
+    for setting in read_settings:
+        if setting in output:
+            continue
+        output.append(setting)
+
+    return output
 
 
 def load_requested_protocols(read_protocols: Optional[List[str]]) -> List[Protocol]:

--- a/iso15118/shared/utils.py
+++ b/iso15118/shared/utils.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 def _format_list(read_settings: List[str]) -> List[str]:
     read_settings = list(filter(None, read_settings))
     read_settings = [setting.strip().upper() for setting in read_settings]
-    read_settings = list(set(read_settings))
-    return read_settings
+    read_settings_set = set(read_settings)
+    return [setting for setting in read_settings if setting in read_settings_set]
 
 
 def load_requested_protocols(read_protocols: Optional[List[str]]) -> List[Protocol]:
@@ -56,7 +56,9 @@ def load_requested_energy_services(
     ]
 
     services = _format_list(read_services)
-    valid_services = list(set(services).intersection(supported_services))
+    valid_services = [
+        service for service in services if service in supported_services
+    ]
     if not valid_services:
         raise NoSupportedEnergyServices(
             f"No supported energy services configured. Supported energy services are "


### PR DESCRIPTION
## Describe your changes

- `select_energy_service_v20` now uses the provided supported_energy_services array as a prioritized list to decide on the selected service. 
- `load_requested_energy_services` now keeps the original order of provided energy services

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

