### PR TITLE
Add options to force requesting/selecting VAS services for ISO15118-2

### DIFF
--- a/iso15118/evcc/controller/simulator.py
+++ b/iso15118/evcc/controller/simulator.py
@@ -560,6 +560,12 @@ class SimEVController(EVControllerInterface):
     async def is_internet_service_needed(self) -> bool:
         return EVEREST_EV_STATE.internet_service_needed
 
+    async def request_all_service_details(self) -> bool:
+        return EVEREST_EV_STATE.all_service_details
+
+    async def select_all_vas_services(self) -> bool:
+        return EVEREST_EV_STATE.all_vas_services
+
     async def process_sa_schedules_dinspec(
         self, sa_schedules: List[SAScheduleTupleEntryDINSPEC]
     ) -> int:
@@ -669,7 +675,7 @@ class SimEVController(EVControllerInterface):
         #     # await asyncio.sleep(0.5)
         #     return True
         return not EVEREST_EV_STATE.StopCharging
-    
+
     async def pause(self) -> bool:
         return EVEREST_EV_STATE.Pause
 

--- a/iso15118/evcc/everest/ev_state.py
+++ b/iso15118/evcc/everest/ev_state.py
@@ -19,6 +19,8 @@ class EVState:
     StopCharging = False
     Pause = False
     internet_service_needed = False
+    all_service_details = False
+    all_vas_services = False
 
     # DC
     dc_max_current_limit: float = DEFAULT_DC_MAX_CURRENT_LIMIT_A

--- a/iso15118/evcc/states/iso15118_2_states.py
+++ b/iso15118/evcc/states/iso15118_2_states.py
@@ -345,13 +345,24 @@ class ServiceDiscovery(StateEVCC):
                 )
                 self.comm_session.sae_j2847_active = service.service_id
 
+            # Request more service details if you're interested in e.g.
+            # an Internet service or a use case-specific service
             if (
                 service.service_category == ServiceCategory.INTERNET
                 and await self.comm_session.ev_controller.is_internet_service_needed()
             ):
                 self.comm_session.service_details_to_request.append(service.service_id)
-            # Request more service details if you're interested in e.g.
-            # an Internet service or a use case-specific service
+            if (
+                service.service_category == ServiceCategory.CUSTOM
+                and await self.comm_session.ev_controller.request_all_service_details()
+            ):
+                self.comm_session.service_details_to_request.append(service.service_id)
+
+                if await self.comm_session.ev_controller.select_all_vas_services():
+                    self.comm_session.selected_services.append(
+                        SelectedService(service_id=service.service_id)
+                    )
+
 
         logger.debug(f"Offered value-added services: {offered_services}")
 
@@ -999,7 +1010,7 @@ class PowerDelivery(StateEVCC):
             dc_ev_charge_params = (
                 await self.comm_session.ev_controller.get_dc_discharge_params()
             )
-        else: 
+        else:
             dc_ev_charge_params = (
                 await self.comm_session.ev_controller.get_dc_charge_params()
             )
@@ -1524,8 +1535,8 @@ class CurrentDemand(StateEVCC):
                     await ev_controller.get_dc_charge_params()
                 )
         # Todo(sl): trigger via node-red bpt and normal charging
-            
-        else: 
+
+        else:
             dc_ev_charge_params = (
                 await ev_controller.get_dc_charge_params()
             )


### PR DESCRIPTION
## Describe your changes

This PR adds helper infrastructure, which can be handy when implementing VAS services.
This is a first step, because while selecting the VAS services, the parameter set is not yet selected.

## Issue ticket number and link

related to https://github.com/EVerest/everest-core/pull/1549

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
