### PR TITLE
feat: Add libcbv2g_json_wrapper core + AppHandshake converter

### DIFF
--- a/iso15118/shared/cbv2g_wrapper/CMakeLists.txt
+++ b/iso15118/shared/cbv2g_wrapper/CMakeLists.txt
@@ -1,0 +1,132 @@
+cmake_minimum_required(VERSION 3.14)
+project(cbv2g_json_wrapper VERSION 1.0.0 LANGUAGES C)
+
+# Set C standard
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Build as shared library
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Try to find libcbv2g via CMake package first (Yocto build)
+find_package(cbv2g QUIET)
+
+if(cbv2g_FOUND)
+    message(STATUS "Found libcbv2g via find_package")
+    set(USE_SYSTEM_LIBCBV2G ON)
+else()
+    message(STATUS "libcbv2g package not found, looking for source directory")
+    set(USE_SYSTEM_LIBCBV2G OFF)
+
+    # Find libcbv2g source directory
+    set(LIBCBV2G_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../../libcbv2g"
+        CACHE PATH "Path to libcbv2g source directory")
+
+    if(NOT EXISTS "${LIBCBV2G_ROOT}/include/cbv2g")
+        message(FATAL_ERROR "libcbv2g not found. Either install the cbv2g package "
+                            "or set LIBCBV2G_ROOT to the source directory.")
+    endif()
+endif()
+
+# cJSON library (embedded)
+add_library(cjson STATIC
+    third_party/cJSON/cJSON.c
+)
+target_include_directories(cjson PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cJSON
+)
+
+# Wrapper sources — only AppHandshake converter for now.
+# DIN, ISO-2, and ISO-20 converters will be added in subsequent PRs.
+set(WRAPPER_SOURCES
+    src/cbv2g_json_wrapper.c
+    src/json_utils.c
+    src/apphand_converter.c
+)
+
+if(USE_SYSTEM_LIBCBV2G)
+    # Using system-installed libcbv2g
+    add_library(cbv2g_json_wrapper SHARED ${WRAPPER_SOURCES})
+
+    target_include_directories(cbv2g_json_wrapper
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cJSON
+    )
+
+    target_link_libraries(cbv2g_json_wrapper
+        PRIVATE
+            cjson
+            cbv2g::cbv2g
+    )
+else()
+    # Build libcbv2g sources directly into our library
+    set(CBVG_COMMON_SOURCES
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_basetypes_decoder.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_basetypes_encoder.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_basetypes.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_bitstream.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_header.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/common/exi_types_decoder.c
+    )
+
+    set(CBVG_APPHAND_SOURCES
+        ${LIBCBV2G_ROOT}/lib/cbv2g/app_handshake/appHand_Datatypes.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/app_handshake/appHand_Decoder.c
+        ${LIBCBV2G_ROOT}/lib/cbv2g/app_handshake/appHand_Encoder.c
+    )
+
+    set(CBVG_TP_SOURCES
+        ${LIBCBV2G_ROOT}/lib/cbv2g/exi_v2gtp.c
+    )
+
+    add_library(cbv2g_json_wrapper SHARED
+        ${CBVG_COMMON_SOURCES}
+        ${CBVG_APPHAND_SOURCES}
+        ${CBVG_TP_SOURCES}
+        ${WRAPPER_SOURCES}
+    )
+
+    target_include_directories(cbv2g_json_wrapper
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cJSON
+            ${LIBCBV2G_ROOT}/include
+    )
+
+    target_link_libraries(cbv2g_json_wrapper
+        PRIVATE
+            cjson
+    )
+endif()
+
+# Set library version
+set_target_properties(cbv2g_json_wrapper PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+# Install rules
+install(TARGETS cbv2g_json_wrapper
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+
+install(FILES include/cbv2g_json_wrapper.h
+    DESTINATION include
+)
+
+# Optional: Build test executable
+option(BUILD_TESTS "Build test executable" OFF)
+if(BUILD_TESTS)
+    add_executable(cbv2g_wrapper_test
+        tests/test_main.c
+    )
+    target_link_libraries(cbv2g_wrapper_test
+        cbv2g_json_wrapper
+    )
+endif()

--- a/iso15118/shared/cbv2g_wrapper/include/cbv2g_json_wrapper.h
+++ b/iso15118/shared/cbv2g_wrapper/include/cbv2g_json_wrapper.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * cbv2g_json_wrapper.h - JSON-based API wrapper for libcbv2g
+ *
+ * This library provides a JSON-based interface to libcbv2g's EXI encoding/decoding
+ * functionality, designed to replace the Java-based EXIficient codec in Josev.
+ */
+
+#ifndef CBV2G_JSON_WRAPPER_H
+#define CBV2G_JSON_WRAPPER_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Version information */
+#define CBV2G_JSON_WRAPPER_VERSION_MAJOR 1
+#define CBV2G_JSON_WRAPPER_VERSION_MINOR 0
+#define CBV2G_JSON_WRAPPER_VERSION_PATCH 0
+#define CBV2G_JSON_WRAPPER_VERSION "1.0.0"
+
+/* Error codes */
+#define CBV2G_SUCCESS                    0
+#define CBV2G_ERROR_INVALID_PARAM       -1
+#define CBV2G_ERROR_BUFFER_TOO_SMALL    -2
+#define CBV2G_ERROR_ENCODING_FAILED     -3
+#define CBV2G_ERROR_DECODING_FAILED     -4
+#define CBV2G_ERROR_UNKNOWN_NAMESPACE   -5
+#define CBV2G_ERROR_JSON_PARSE          -6
+#define CBV2G_ERROR_JSON_GENERATE       -7
+#define CBV2G_ERROR_UNKNOWN_MESSAGE     -8
+#define CBV2G_ERROR_INTERNAL            -9
+
+/* Namespace constants matching Josev's Namespace enum */
+#define NS_DIN_MSG_DEF          "urn:din:70121:2012:MsgDef"
+#define NS_ISO_V2_MSG_DEF       "urn:iso:15118:2:2013:MsgDef"
+#define NS_ISO_V20_BASE         "urn:iso:std:iso:15118:-20"
+#define NS_ISO_V20_COMMON_MSG   "urn:iso:std:iso:15118:-20:CommonMessages"
+#define NS_ISO_V20_AC           "urn:iso:std:iso:15118:-20:AC"
+#define NS_ISO_V20_DC           "urn:iso:std:iso:15118:-20:DC"
+#define NS_ISO_V20_WPT          "urn:iso:std:iso:15118:-20:WPT"
+#define NS_ISO_V20_ACDP         "urn:iso:std:iso:15118:-20:ACDP"
+#define NS_SAP                  "urn:iso:15118:2:2010:AppProtocol"
+
+/**
+ * @brief Encode a JSON message to EXI format
+ *
+ * @param json_message  JSON string containing the message to encode
+ * @param namespace     Namespace string identifying the protocol/schema
+ * @param output_buffer Buffer to receive the EXI-encoded bytes
+ * @param buffer_size   Size of the output buffer
+ * @param output_length Pointer to receive the actual length of encoded data
+ *
+ * @return CBV2G_SUCCESS on success, negative error code on failure
+ */
+int cbv2g_encode(const char* json_message,
+                 const char* namespace,
+                 uint8_t* output_buffer,
+                 size_t buffer_size,
+                 size_t* output_length);
+
+/**
+ * @brief Decode EXI data to JSON format
+ *
+ * @param exi_data      EXI-encoded byte array
+ * @param exi_length    Length of the EXI data
+ * @param namespace     Namespace string identifying the protocol/schema
+ * @param output_json   Buffer to receive the JSON string
+ * @param buffer_size   Size of the output buffer
+ *
+ * @return CBV2G_SUCCESS on success, negative error code on failure
+ */
+int cbv2g_decode(const uint8_t* exi_data,
+                 size_t exi_length,
+                 const char* namespace,
+                 char* output_json,
+                 size_t buffer_size);
+
+/**
+ * @brief Get the version string of this library
+ *
+ * @return Version string (e.g., "1.0.0")
+ */
+const char* cbv2g_get_version(void);
+
+/**
+ * @brief Get the last error message
+ *
+ * @return Error message string, or empty string if no error
+ */
+const char* cbv2g_get_last_error(void);
+
+/**
+ * @brief Clear the last error message
+ */
+void cbv2g_clear_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CBV2G_JSON_WRAPPER_H */

--- a/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
+++ b/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
@@ -192,7 +192,7 @@ static int json_to_apphand_req(cJSON* json, struct appHand_supportedAppProtocolR
 
         /* ProtocolNamespace */
         const char* ns = json_get_string(item, "ProtocolNamespace");
-        size_t ns_len = strlen(ns);
+        size_t ns_len = strnlen(ns, appHand_ProtocolNamespace_CHARACTER_SIZE);
         if (ns_len >= appHand_ProtocolNamespace_CHARACTER_SIZE) {
             ns_len = appHand_ProtocolNamespace_CHARACTER_SIZE - 1;
         }
@@ -220,11 +220,14 @@ static int json_to_apphand_res(cJSON* json, struct appHand_supportedAppProtocolR
 
     /* ResponseCode */
     const char* response_code = json_get_string(json, "ResponseCode");
-    if (strcmp(response_code, "OK_SuccessfulNegotiation") == 0) {
+    if (strncmp(response_code, "OK_SuccessfulNegotiation",
+                sizeof("OK_SuccessfulNegotiation")) == 0) {
         res->ResponseCode = appHand_responseCodeType_OK_SuccessfulNegotiation;
-    } else if (strcmp(response_code, "OK_SuccessfulNegotiationWithMinorDeviation") == 0) {
+    } else if (strncmp(response_code, "OK_SuccessfulNegotiationWithMinorDeviation",
+                       sizeof("OK_SuccessfulNegotiationWithMinorDeviation")) == 0) {
         res->ResponseCode = appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation;
-    } else if (strcmp(response_code, "Failed_NoNegotiation") == 0) {
+    } else if (strncmp(response_code, "Failed_NoNegotiation",
+                       sizeof("Failed_NoNegotiation")) == 0) {
         res->ResponseCode = appHand_responseCodeType_Failed_NoNegotiation;
     } else {
         /* Try as integer */

--- a/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
+++ b/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
@@ -1,0 +1,319 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * apphand_converter.c - App Handshake (SAP) JSON/EXI converter
+ */
+
+#include "converters.h"
+#include "json_utils.h"
+#include "cJSON.h"
+
+#include <cbv2g/common/exi_bitstream.h>
+#include <cbv2g/app_handshake/appHand_Datatypes.h>
+#include <cbv2g/app_handshake/appHand_Encoder.h>
+#include <cbv2g/app_handshake/appHand_Decoder.h>
+
+#include <string.h>
+#include <stdio.h>
+
+/* Forward declarations */
+static int json_to_apphand_req(cJSON* json, struct appHand_supportedAppProtocolReq* req);
+static int json_to_apphand_res(cJSON* json, struct appHand_supportedAppProtocolRes* res);
+static cJSON* apphand_req_to_json(const struct appHand_supportedAppProtocolReq* req);
+static cJSON* apphand_res_to_json(const struct appHand_supportedAppProtocolRes* res);
+
+/*
+ * Encode App Handshake message from JSON to EXI
+ */
+int apphand_encode(const char* json_str, uint8_t* out, size_t out_size, size_t* out_len) {
+    int result = CBV2G_ERROR_INTERNAL;
+    cJSON* root = NULL;
+    cJSON* msg = NULL;
+
+    /* Parse JSON */
+    root = cJSON_Parse(json_str);
+    if (root == NULL) {
+        set_error("Failed to parse JSON: %s", cJSON_GetErrorPtr());
+        return CBV2G_ERROR_JSON_PARSE;
+    }
+
+    /* Initialize EXI document */
+    struct appHand_exiDocument doc;
+    init_appHand_exiDocument(&doc);
+
+    /* Determine message type and convert */
+    msg = cJSON_GetObjectItemCaseSensitive(root, "supportedAppProtocolReq");
+    if (msg != NULL) {
+        doc.supportedAppProtocolReq_isUsed = 1;
+        result = json_to_apphand_req(msg, &doc.supportedAppProtocolReq);
+        if (result != CBV2G_SUCCESS) {
+            goto cleanup;
+        }
+    } else {
+        msg = cJSON_GetObjectItemCaseSensitive(root, "supportedAppProtocolRes");
+        if (msg != NULL) {
+            doc.supportedAppProtocolRes_isUsed = 1;
+            result = json_to_apphand_res(msg, &doc.supportedAppProtocolRes);
+            if (result != CBV2G_SUCCESS) {
+                goto cleanup;
+            }
+        } else {
+            set_error("Unknown App Handshake message type");
+            result = CBV2G_ERROR_UNKNOWN_MESSAGE;
+            goto cleanup;
+        }
+    }
+
+    /* Initialize EXI bitstream */
+    exi_bitstream_t stream;
+    exi_bitstream_init(&stream, out, out_size, 0, NULL);
+
+    /* Encode to EXI */
+    int exi_result = encode_appHand_exiDocument(&stream, &doc);
+    if (exi_result != 0) {
+        set_error("EXI encoding failed with error code: %d", exi_result);
+        result = CBV2G_ERROR_ENCODING_FAILED;
+        goto cleanup;
+    }
+
+    *out_len = exi_bitstream_get_length(&stream);
+    result = CBV2G_SUCCESS;
+
+cleanup:
+    if (root != NULL) {
+        cJSON_Delete(root);
+    }
+    return result;
+}
+
+/*
+ * Decode App Handshake message from EXI to JSON
+ */
+int apphand_decode(const uint8_t* exi, size_t exi_len, char* out, size_t out_size) {
+    int result = CBV2G_ERROR_INTERNAL;
+    cJSON* json = NULL;
+    char* json_str = NULL;
+
+    /* Initialize EXI bitstream */
+    exi_bitstream_t stream;
+    exi_bitstream_init(&stream, (uint8_t*)exi, exi_len, 0, NULL);
+
+    /* Initialize and decode EXI document */
+    struct appHand_exiDocument doc;
+    init_appHand_exiDocument(&doc);
+
+    int exi_result = decode_appHand_exiDocument(&stream, &doc);
+    if (exi_result != 0) {
+        set_error("EXI decoding failed with error code: %d", exi_result);
+        return CBV2G_ERROR_DECODING_FAILED;
+    }
+
+    /* Convert to JSON based on message type */
+    json = cJSON_CreateObject();
+    if (json == NULL) {
+        set_error("Failed to create JSON object");
+        return CBV2G_ERROR_JSON_GENERATE;
+    }
+
+    if (doc.supportedAppProtocolReq_isUsed) {
+        cJSON* req_json = apphand_req_to_json(&doc.supportedAppProtocolReq);
+        if (req_json == NULL) {
+            set_error("Failed to convert supportedAppProtocolReq to JSON");
+            result = CBV2G_ERROR_JSON_GENERATE;
+            goto cleanup;
+        }
+        cJSON_AddItemToObject(json, "supportedAppProtocolReq", req_json);
+    } else if (doc.supportedAppProtocolRes_isUsed) {
+        cJSON* res_json = apphand_res_to_json(&doc.supportedAppProtocolRes);
+        if (res_json == NULL) {
+            set_error("Failed to convert supportedAppProtocolRes to JSON");
+            result = CBV2G_ERROR_JSON_GENERATE;
+            goto cleanup;
+        }
+        cJSON_AddItemToObject(json, "supportedAppProtocolRes", res_json);
+    } else {
+        set_error("No valid message found in decoded document");
+        result = CBV2G_ERROR_DECODING_FAILED;
+        goto cleanup;
+    }
+
+    /* Serialize JSON to string */
+    json_str = cJSON_PrintUnformatted(json);
+    if (json_str == NULL) {
+        set_error("Failed to serialize JSON");
+        result = CBV2G_ERROR_JSON_GENERATE;
+        goto cleanup;
+    }
+
+    /* Copy to output buffer */
+    size_t json_len = strlen(json_str);
+    if (json_len >= out_size) {
+        set_error("Output buffer too small: need %zu, have %zu", json_len + 1, out_size);
+        result = CBV2G_ERROR_BUFFER_TOO_SMALL;
+        goto cleanup;
+    }
+
+    strcpy(out, json_str);
+    result = CBV2G_SUCCESS;
+
+cleanup:
+    if (json != NULL) {
+        cJSON_Delete(json);
+    }
+    if (json_str != NULL) {
+        cJSON_free(json_str);
+    }
+    return result;
+}
+
+/*
+ * Convert JSON to supportedAppProtocolReq struct
+ */
+static int json_to_apphand_req(cJSON* json, struct appHand_supportedAppProtocolReq* req) {
+    init_appHand_supportedAppProtocolReq(req);
+
+    cJSON* app_protocol = cJSON_GetObjectItemCaseSensitive(json, "AppProtocol");
+    if (app_protocol == NULL || !cJSON_IsArray(app_protocol)) {
+        set_error("AppProtocol array not found or not an array");
+        return CBV2G_ERROR_JSON_PARSE;
+    }
+
+    int count = cJSON_GetArraySize(app_protocol);
+    if (count > appHand_AppProtocolType_5_ARRAY_SIZE) {
+        count = appHand_AppProtocolType_5_ARRAY_SIZE;
+    }
+    req->AppProtocol.arrayLen = count;
+
+    for (int i = 0; i < count; i++) {
+        cJSON* item = cJSON_GetArrayItem(app_protocol, i);
+        struct appHand_AppProtocolType* proto = &req->AppProtocol.array[i];
+        init_appHand_AppProtocolType(proto);
+
+        /* ProtocolNamespace */
+        const char* ns = json_get_string(item, "ProtocolNamespace");
+        size_t ns_len = strlen(ns);
+        if (ns_len >= appHand_ProtocolNamespace_CHARACTER_SIZE) {
+            ns_len = appHand_ProtocolNamespace_CHARACTER_SIZE - 1;
+        }
+        strncpy(proto->ProtocolNamespace.characters, ns, ns_len);
+        proto->ProtocolNamespace.characters[ns_len] = '\0';
+        proto->ProtocolNamespace.charactersLen = ns_len;
+
+        /* Version numbers */
+        proto->VersionNumberMajor = json_get_int(item, "VersionNumberMajor");
+        proto->VersionNumberMinor = json_get_int(item, "VersionNumberMinor");
+
+        /* SchemaID and Priority */
+        proto->SchemaID = json_get_int(item, "SchemaID");
+        proto->Priority = json_get_int(item, "Priority");
+    }
+
+    return CBV2G_SUCCESS;
+}
+
+/*
+ * Convert JSON to supportedAppProtocolRes struct
+ */
+static int json_to_apphand_res(cJSON* json, struct appHand_supportedAppProtocolRes* res) {
+    init_appHand_supportedAppProtocolRes(res);
+
+    /* ResponseCode */
+    const char* response_code = json_get_string(json, "ResponseCode");
+    if (strcmp(response_code, "OK_SuccessfulNegotiation") == 0) {
+        res->ResponseCode = appHand_responseCodeType_OK_SuccessfulNegotiation;
+    } else if (strcmp(response_code, "OK_SuccessfulNegotiationWithMinorDeviation") == 0) {
+        res->ResponseCode = appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation;
+    } else if (strcmp(response_code, "Failed_NoNegotiation") == 0) {
+        res->ResponseCode = appHand_responseCodeType_Failed_NoNegotiation;
+    } else {
+        /* Try as integer */
+        res->ResponseCode = json_get_int(json, "ResponseCode");
+    }
+
+    /* SchemaID (optional) */
+    if (json_has_key(json, "SchemaID")) {
+        res->SchemaID = json_get_int(json, "SchemaID");
+        res->SchemaID_isUsed = 1;
+    }
+
+    return CBV2G_SUCCESS;
+}
+
+/*
+ * Convert supportedAppProtocolReq struct to JSON
+ */
+static cJSON* apphand_req_to_json(const struct appHand_supportedAppProtocolReq* req) {
+    cJSON* json = cJSON_CreateObject();
+    if (json == NULL) return NULL;
+
+    cJSON* app_protocol = cJSON_CreateArray();
+    if (app_protocol == NULL) {
+        cJSON_Delete(json);
+        return NULL;
+    }
+
+    for (int i = 0; i < req->AppProtocol.arrayLen; i++) {
+        const struct appHand_AppProtocolType* proto = &req->AppProtocol.array[i];
+
+        cJSON* item = cJSON_CreateObject();
+        if (item == NULL) {
+            cJSON_Delete(app_protocol);
+            cJSON_Delete(json);
+            return NULL;
+        }
+
+        /* Create null-terminated string for ProtocolNamespace */
+        char ns[appHand_ProtocolNamespace_CHARACTER_SIZE + 1];
+        size_t ns_len = proto->ProtocolNamespace.charactersLen;
+        if (ns_len > appHand_ProtocolNamespace_CHARACTER_SIZE) {
+            ns_len = appHand_ProtocolNamespace_CHARACTER_SIZE;
+        }
+        memcpy(ns, proto->ProtocolNamespace.characters, ns_len);
+        ns[ns_len] = '\0';
+
+        cJSON_AddStringToObject(item, "ProtocolNamespace", ns);
+        cJSON_AddNumberToObject(item, "VersionNumberMajor", proto->VersionNumberMajor);
+        cJSON_AddNumberToObject(item, "VersionNumberMinor", proto->VersionNumberMinor);
+        cJSON_AddNumberToObject(item, "SchemaID", proto->SchemaID);
+        cJSON_AddNumberToObject(item, "Priority", proto->Priority);
+
+        cJSON_AddItemToArray(app_protocol, item);
+    }
+
+    cJSON_AddItemToObject(json, "AppProtocol", app_protocol);
+    return json;
+}
+
+/*
+ * Convert supportedAppProtocolRes struct to JSON
+ */
+static cJSON* apphand_res_to_json(const struct appHand_supportedAppProtocolRes* res) {
+    cJSON* json = cJSON_CreateObject();
+    if (json == NULL) return NULL;
+
+    /* ResponseCode as string */
+    const char* response_code_str;
+    switch (res->ResponseCode) {
+        case appHand_responseCodeType_OK_SuccessfulNegotiation:
+            response_code_str = "OK_SuccessfulNegotiation";
+            break;
+        case appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation:
+            response_code_str = "OK_SuccessfulNegotiationWithMinorDeviation";
+            break;
+        case appHand_responseCodeType_Failed_NoNegotiation:
+            response_code_str = "Failed_NoNegotiation";
+            break;
+        default:
+            response_code_str = "Unknown";
+            break;
+    }
+    cJSON_AddStringToObject(json, "ResponseCode", response_code_str);
+
+    /* SchemaID (optional) */
+    if (res->SchemaID_isUsed) {
+        cJSON_AddNumberToObject(json, "SchemaID", res->SchemaID);
+    }
+
+    return json;
+}

--- a/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
+++ b/iso15118/shared/cbv2g_wrapper/src/apphand_converter.c
@@ -146,15 +146,13 @@ int apphand_decode(const uint8_t* exi, size_t exi_len, char* out, size_t out_siz
         goto cleanup;
     }
 
-    /* Copy to output buffer */
-    size_t json_len = strlen(json_str);
-    if (json_len >= out_size) {
-        set_error("Output buffer too small: need %zu, have %zu", json_len + 1, out_size);
+    /* Copy to output buffer using snprintf for bounded write */
+    int written = snprintf(out, out_size, "%s", json_str);
+    if (written < 0 || (size_t)written >= out_size) {
+        set_error("Output buffer too small: need %d, have %zu", written + 1, out_size);
         result = CBV2G_ERROR_BUFFER_TOO_SMALL;
         goto cleanup;
     }
-
-    strcpy(out, json_str);
     result = CBV2G_SUCCESS;
 
 cleanup:
@@ -190,15 +188,16 @@ static int json_to_apphand_req(cJSON* json, struct appHand_supportedAppProtocolR
         struct appHand_AppProtocolType* proto = &req->AppProtocol.array[i];
         init_appHand_AppProtocolType(proto);
 
-        /* ProtocolNamespace */
+        /* ProtocolNamespace — snprintf with %.*s is bounded and always null-terminates */
         const char* ns = json_get_string(item, "ProtocolNamespace");
         size_t ns_len = strnlen(ns, appHand_ProtocolNamespace_CHARACTER_SIZE);
-        if (ns_len >= appHand_ProtocolNamespace_CHARACTER_SIZE) {
-            ns_len = appHand_ProtocolNamespace_CHARACTER_SIZE - 1;
-        }
-        strncpy(proto->ProtocolNamespace.characters, ns, ns_len);
-        proto->ProtocolNamespace.characters[ns_len] = '\0';
-        proto->ProtocolNamespace.charactersLen = ns_len;
+        int ns_written = snprintf(proto->ProtocolNamespace.characters,
+                                  appHand_ProtocolNamespace_CHARACTER_SIZE,
+                                  "%.*s", (int)ns_len, ns);
+        if (ns_written < 0) ns_written = 0;
+        if ((size_t)ns_written >= appHand_ProtocolNamespace_CHARACTER_SIZE)
+            ns_written = appHand_ProtocolNamespace_CHARACTER_SIZE - 1;
+        proto->ProtocolNamespace.charactersLen = (size_t)ns_written;
 
         /* Version numbers */
         proto->VersionNumberMajor = json_get_int(item, "VersionNumberMajor");
@@ -272,8 +271,8 @@ static cJSON* apphand_req_to_json(const struct appHand_supportedAppProtocolReq* 
         if (ns_len > appHand_ProtocolNamespace_CHARACTER_SIZE) {
             ns_len = appHand_ProtocolNamespace_CHARACTER_SIZE;
         }
-        memcpy(ns, proto->ProtocolNamespace.characters, ns_len);
-        ns[ns_len] = '\0';
+        snprintf(ns, sizeof(ns), "%.*s", (int)ns_len,
+                 proto->ProtocolNamespace.characters);
 
         cJSON_AddStringToObject(item, "ProtocolNamespace", ns);
         cJSON_AddNumberToObject(item, "VersionNumberMajor", proto->VersionNumberMajor);

--- a/iso15118/shared/cbv2g_wrapper/src/cbv2g_json_wrapper.c
+++ b/iso15118/shared/cbv2g_wrapper/src/cbv2g_json_wrapper.c
@@ -51,32 +51,32 @@ static protocol_t get_protocol(const char* namespace) {
         return PROTOCOL_UNKNOWN;
     }
 
-    if (strcmp(namespace, NS_SAP) == 0) {
+    if (strncmp(namespace, NS_SAP, sizeof(NS_SAP)) == 0) {
         return PROTOCOL_SAP;
     }
-    if (strcmp(namespace, NS_DIN_MSG_DEF) == 0) {
+    if (strncmp(namespace, NS_DIN_MSG_DEF, sizeof(NS_DIN_MSG_DEF)) == 0) {
         return PROTOCOL_DIN;
     }
-    if (strcmp(namespace, NS_ISO_V2_MSG_DEF) == 0) {
+    if (strncmp(namespace, NS_ISO_V2_MSG_DEF, sizeof(NS_ISO_V2_MSG_DEF)) == 0) {
         return PROTOCOL_ISO2;
     }
-    if (strcmp(namespace, NS_ISO_V20_COMMON_MSG) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_COMMON_MSG, sizeof(NS_ISO_V20_COMMON_MSG)) == 0) {
         return PROTOCOL_ISO20_COMMON;
     }
-    if (strcmp(namespace, NS_ISO_V20_AC) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_AC, sizeof(NS_ISO_V20_AC)) == 0) {
         return PROTOCOL_ISO20_AC;
     }
-    if (strcmp(namespace, NS_ISO_V20_DC) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_DC, sizeof(NS_ISO_V20_DC)) == 0) {
         return PROTOCOL_ISO20_DC;
     }
-    if (strcmp(namespace, NS_ISO_V20_WPT) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_WPT, sizeof(NS_ISO_V20_WPT)) == 0) {
         return PROTOCOL_ISO20_WPT;
     }
-    if (strcmp(namespace, NS_ISO_V20_ACDP) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_ACDP, sizeof(NS_ISO_V20_ACDP)) == 0) {
         return PROTOCOL_ISO20_ACDP;
     }
     /* Check for ISO20 base prefix */
-    if (strncmp(namespace, NS_ISO_V20_BASE, strlen(NS_ISO_V20_BASE)) == 0) {
+    if (strncmp(namespace, NS_ISO_V20_BASE, sizeof(NS_ISO_V20_BASE) - 1) == 0) {
         return PROTOCOL_ISO20_COMMON;
     }
 

--- a/iso15118/shared/cbv2g_wrapper/src/cbv2g_json_wrapper.c
+++ b/iso15118/shared/cbv2g_wrapper/src/cbv2g_json_wrapper.c
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * cbv2g_json_wrapper.c - Main wrapper implementation
+ */
+
+#include "cbv2g_json_wrapper.h"
+#include "converters.h"
+#include <string.h>
+#include <stdio.h>
+
+/* Thread-local error message buffer */
+static __thread char g_last_error[1024] = {0};
+
+/* Internal function to set error message */
+void set_error(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vsnprintf(g_last_error, sizeof(g_last_error), format, args);
+    va_end(args);
+}
+
+const char* cbv2g_get_version(void) {
+    return CBV2G_JSON_WRAPPER_VERSION;
+}
+
+const char* cbv2g_get_last_error(void) {
+    return g_last_error;
+}
+
+void cbv2g_clear_error(void) {
+    g_last_error[0] = '\0';
+}
+
+/* Determine protocol from namespace */
+typedef enum {
+    PROTOCOL_UNKNOWN = 0,
+    PROTOCOL_SAP,
+    PROTOCOL_DIN,
+    PROTOCOL_ISO2,
+    PROTOCOL_ISO20_COMMON,
+    PROTOCOL_ISO20_AC,
+    PROTOCOL_ISO20_DC,
+    PROTOCOL_ISO20_WPT,
+    PROTOCOL_ISO20_ACDP
+} protocol_t;
+
+static protocol_t get_protocol(const char* namespace) {
+    if (namespace == NULL) {
+        return PROTOCOL_UNKNOWN;
+    }
+
+    if (strcmp(namespace, NS_SAP) == 0) {
+        return PROTOCOL_SAP;
+    }
+    if (strcmp(namespace, NS_DIN_MSG_DEF) == 0) {
+        return PROTOCOL_DIN;
+    }
+    if (strcmp(namespace, NS_ISO_V2_MSG_DEF) == 0) {
+        return PROTOCOL_ISO2;
+    }
+    if (strcmp(namespace, NS_ISO_V20_COMMON_MSG) == 0) {
+        return PROTOCOL_ISO20_COMMON;
+    }
+    if (strcmp(namespace, NS_ISO_V20_AC) == 0) {
+        return PROTOCOL_ISO20_AC;
+    }
+    if (strcmp(namespace, NS_ISO_V20_DC) == 0) {
+        return PROTOCOL_ISO20_DC;
+    }
+    if (strcmp(namespace, NS_ISO_V20_WPT) == 0) {
+        return PROTOCOL_ISO20_WPT;
+    }
+    if (strcmp(namespace, NS_ISO_V20_ACDP) == 0) {
+        return PROTOCOL_ISO20_ACDP;
+    }
+    /* Check for ISO20 base prefix */
+    if (strncmp(namespace, NS_ISO_V20_BASE, strlen(NS_ISO_V20_BASE)) == 0) {
+        return PROTOCOL_ISO20_COMMON;
+    }
+
+    return PROTOCOL_UNKNOWN;
+}
+
+int cbv2g_encode(const char* json_message,
+                 const char* namespace,
+                 uint8_t* output_buffer,
+                 size_t buffer_size,
+                 size_t* output_length) {
+
+    /* Validate parameters */
+    if (json_message == NULL || namespace == NULL ||
+        output_buffer == NULL || output_length == NULL) {
+        set_error("Invalid parameter: NULL pointer");
+        return CBV2G_ERROR_INVALID_PARAM;
+    }
+
+    if (buffer_size == 0) {
+        set_error("Invalid parameter: buffer_size is 0");
+        return CBV2G_ERROR_INVALID_PARAM;
+    }
+
+    cbv2g_clear_error();
+
+    /* Route to appropriate protocol encoder */
+    protocol_t protocol = get_protocol(namespace);
+
+    switch (protocol) {
+        case PROTOCOL_SAP:
+            return apphand_encode(json_message, output_buffer, buffer_size, output_length);
+
+        /*
+         * DIN, ISO-2, and ISO-20 converters will be added in subsequent PRs.
+         * For now, these namespaces are recognized but not yet supported.
+         */
+        case PROTOCOL_DIN:
+        case PROTOCOL_ISO2:
+        case PROTOCOL_ISO20_COMMON:
+        case PROTOCOL_ISO20_AC:
+        case PROTOCOL_ISO20_DC:
+        case PROTOCOL_ISO20_WPT:
+        case PROTOCOL_ISO20_ACDP:
+            set_error("Protocol not yet supported: %s", namespace);
+            return CBV2G_ERROR_UNKNOWN_NAMESPACE;
+
+        default:
+            set_error("Unknown namespace: %s", namespace);
+            return CBV2G_ERROR_UNKNOWN_NAMESPACE;
+    }
+}
+
+int cbv2g_decode(const uint8_t* exi_data,
+                 size_t exi_length,
+                 const char* namespace,
+                 char* output_json,
+                 size_t buffer_size) {
+
+    /* Validate parameters */
+    if (exi_data == NULL || namespace == NULL || output_json == NULL) {
+        set_error("Invalid parameter: NULL pointer");
+        return CBV2G_ERROR_INVALID_PARAM;
+    }
+
+    if (exi_length == 0 || buffer_size == 0) {
+        set_error("Invalid parameter: length is 0");
+        return CBV2G_ERROR_INVALID_PARAM;
+    }
+
+    cbv2g_clear_error();
+
+    /* Route to appropriate protocol decoder */
+    protocol_t protocol = get_protocol(namespace);
+
+    switch (protocol) {
+        case PROTOCOL_SAP:
+            return apphand_decode(exi_data, exi_length, output_json, buffer_size);
+
+        /*
+         * DIN, ISO-2, and ISO-20 converters will be added in subsequent PRs.
+         * For now, these namespaces are recognized but not yet supported.
+         */
+        case PROTOCOL_DIN:
+        case PROTOCOL_ISO2:
+        case PROTOCOL_ISO20_COMMON:
+        case PROTOCOL_ISO20_AC:
+        case PROTOCOL_ISO20_DC:
+        case PROTOCOL_ISO20_WPT:
+        case PROTOCOL_ISO20_ACDP:
+            set_error("Protocol not yet supported: %s", namespace);
+            return CBV2G_ERROR_UNKNOWN_NAMESPACE;
+
+        default:
+            set_error("Unknown namespace: %s", namespace);
+            return CBV2G_ERROR_UNKNOWN_NAMESPACE;
+    }
+}

--- a/iso15118/shared/cbv2g_wrapper/src/converters.h
+++ b/iso15118/shared/cbv2g_wrapper/src/converters.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * converters.h - Internal header for protocol converters
+ */
+
+#ifndef CONVERTERS_H
+#define CONVERTERS_H
+
+#include "cbv2g_json_wrapper.h"
+#include <stdarg.h>
+
+/* Error handling */
+void set_error(const char* format, ...);
+
+/* App Handshake converter */
+int apphand_encode(const char* json, uint8_t* out, size_t out_size, size_t* out_len);
+int apphand_decode(const uint8_t* exi, size_t exi_len, char* out, size_t out_size);
+
+#endif /* CONVERTERS_H */

--- a/iso15118/shared/cbv2g_wrapper/src/json_utils.c
+++ b/iso15118/shared/cbv2g_wrapper/src/json_utils.c
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * json_utils.c - JSON parsing and generation utilities
+ */
+
+#include "json_utils.h"
+#include "cJSON.h"
+#include <string.h>
+#include <stdlib.h>
+
+/* Base64 encoding/decoding tables */
+static const char base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static const int base64_decode_table[256] = {
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,62,-1,-1,-1,63,
+    52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-1,-1,-1,
+    -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,
+    15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,
+    -1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,
+    41,42,43,44,45,46,47,48,49,50,51,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+    -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1
+};
+
+size_t base64_encode(const uint8_t* input, size_t input_len, char* output, size_t output_size) {
+    size_t output_len = ((input_len + 2) / 3) * 4;
+
+    if (output_size < output_len + 1) {
+        return 0;
+    }
+
+    size_t i, j;
+    for (i = 0, j = 0; i < input_len; i += 3, j += 4) {
+        uint32_t octet_a = i < input_len ? input[i] : 0;
+        uint32_t octet_b = i + 1 < input_len ? input[i + 1] : 0;
+        uint32_t octet_c = i + 2 < input_len ? input[i + 2] : 0;
+
+        uint32_t triple = (octet_a << 16) + (octet_b << 8) + octet_c;
+
+        output[j] = base64_chars[(triple >> 18) & 0x3F];
+        output[j + 1] = base64_chars[(triple >> 12) & 0x3F];
+        output[j + 2] = (i + 1 < input_len) ? base64_chars[(triple >> 6) & 0x3F] : '=';
+        output[j + 3] = (i + 2 < input_len) ? base64_chars[triple & 0x3F] : '=';
+    }
+
+    output[j] = '\0';
+    return j;
+}
+
+size_t base64_decode(const char* input, size_t input_len, uint8_t* output, size_t output_size) {
+    if (input_len % 4 != 0) {
+        return 0;
+    }
+
+    size_t output_len = input_len / 4 * 3;
+    if (input[input_len - 1] == '=') output_len--;
+    if (input[input_len - 2] == '=') output_len--;
+
+    if (output_size < output_len) {
+        return 0;
+    }
+
+    size_t i, j;
+    for (i = 0, j = 0; i < input_len; i += 4) {
+        int a = base64_decode_table[(unsigned char)input[i]];
+        int b = base64_decode_table[(unsigned char)input[i + 1]];
+        int c = base64_decode_table[(unsigned char)input[i + 2]];
+        int d = base64_decode_table[(unsigned char)input[i + 3]];
+
+        if (a < 0 || b < 0) return 0;
+
+        uint32_t triple = (a << 18) + (b << 12);
+        if (c >= 0) triple += (c << 6);
+        if (d >= 0) triple += d;
+
+        if (j < output_len) output[j++] = (triple >> 16) & 0xFF;
+        if (j < output_len) output[j++] = (triple >> 8) & 0xFF;
+        if (j < output_len) output[j++] = triple & 0xFF;
+    }
+
+    return output_len;
+}
+
+/* Hex encoding table */
+static const char hex_chars[] = "0123456789abcdef";
+
+size_t hex_encode(const uint8_t* input, size_t input_len, char* output, size_t output_size) {
+    size_t output_len = input_len * 2;
+
+    if (output_size < output_len + 1) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < input_len; i++) {
+        output[i * 2] = hex_chars[(input[i] >> 4) & 0x0F];
+        output[i * 2 + 1] = hex_chars[input[i] & 0x0F];
+    }
+    output[output_len] = '\0';
+
+    return output_len;
+}
+
+static int hex_char_to_int(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+size_t hex_decode(const char* input, size_t input_len, uint8_t* output, size_t output_size) {
+    /* Hex string must have even length */
+    if (input_len % 2 != 0) {
+        return 0;
+    }
+
+    size_t output_len = input_len / 2;
+
+    if (output_size < output_len) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < output_len; i++) {
+        int high = hex_char_to_int(input[i * 2]);
+        int low = hex_char_to_int(input[i * 2 + 1]);
+
+        if (high < 0 || low < 0) {
+            return 0;  /* Invalid hex character */
+        }
+
+        output[i] = (high << 4) | low;
+    }
+
+    return output_len;
+}
+
+/* Get string from JSON object, returns empty string if not found */
+const char* json_get_string(cJSON* obj, const char* key) {
+    cJSON* item = cJSON_GetObjectItemCaseSensitive(obj, key);
+    if (item && cJSON_IsString(item)) {
+        return item->valuestring;
+    }
+    return "";
+}
+
+/* Get integer from JSON object, returns 0 if not found */
+int json_get_int(cJSON* obj, const char* key) {
+    cJSON* item = cJSON_GetObjectItemCaseSensitive(obj, key);
+    if (item && cJSON_IsNumber(item)) {
+        return item->valueint;
+    }
+    return 0;
+}
+
+/* Get boolean from JSON object, returns 0 if not found */
+int json_get_bool(cJSON* obj, const char* key) {
+    cJSON* item = cJSON_GetObjectItemCaseSensitive(obj, key);
+    if (item) {
+        return cJSON_IsTrue(item) ? 1 : 0;
+    }
+    return 0;
+}
+
+/* Check if key exists in JSON object */
+int json_has_key(cJSON* obj, const char* key) {
+    return cJSON_GetObjectItemCaseSensitive(obj, key) != NULL;
+}
+
+/* Get bytes from base64-encoded JSON string */
+size_t json_get_bytes(cJSON* obj, const char* key, uint8_t* output, size_t output_size) {
+    cJSON* item = cJSON_GetObjectItemCaseSensitive(obj, key);
+    if (item && cJSON_IsString(item)) {
+        return base64_decode(item->valuestring, strlen(item->valuestring), output, output_size);
+    }
+    return 0;
+}
+
+/* Add bytes as base64-encoded string to JSON object */
+void json_add_bytes(cJSON* obj, const char* key, const uint8_t* data, size_t data_len) {
+    char* encoded = malloc(((data_len + 2) / 3) * 4 + 1);
+    if (encoded) {
+        base64_encode(data, data_len, encoded, ((data_len + 2) / 3) * 4 + 1);
+        cJSON_AddStringToObject(obj, key, encoded);
+        free(encoded);
+    }
+}

--- a/iso15118/shared/cbv2g_wrapper/src/json_utils.c
+++ b/iso15118/shared/cbv2g_wrapper/src/json_utils.c
@@ -180,7 +180,9 @@ int json_has_key(cJSON* obj, const char* key) {
 size_t json_get_bytes(cJSON* obj, const char* key, uint8_t* output, size_t output_size) {
     cJSON* item = cJSON_GetObjectItemCaseSensitive(obj, key);
     if (item && cJSON_IsString(item)) {
-        return base64_decode(item->valuestring, strlen(item->valuestring), output, output_size);
+        size_t max_b64_len = ((output_size + 2) / 3) * 4;
+        size_t vs_len = strnlen(item->valuestring, max_b64_len);
+        return base64_decode(item->valuestring, vs_len, output, output_size);
     }
     return 0;
 }

--- a/iso15118/shared/cbv2g_wrapper/src/json_utils.h
+++ b/iso15118/shared/cbv2g_wrapper/src/json_utils.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2024 Contributors to EVerest
+ *
+ * json_utils.h - JSON parsing and generation utilities
+ */
+
+#ifndef JSON_UTILS_H
+#define JSON_UTILS_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "cJSON.h"
+
+/* Base64 encoding/decoding */
+size_t base64_encode(const uint8_t* input, size_t input_len, char* output, size_t output_size);
+size_t base64_decode(const char* input, size_t input_len, uint8_t* output, size_t output_size);
+
+/* Hex encoding/decoding (for hexBinary XSD types) */
+size_t hex_encode(const uint8_t* input, size_t input_len, char* output, size_t output_size);
+size_t hex_decode(const char* input, size_t input_len, uint8_t* output, size_t output_size);
+
+/* JSON helper functions */
+const char* json_get_string(cJSON* obj, const char* key);
+int json_get_int(cJSON* obj, const char* key);
+int json_get_bool(cJSON* obj, const char* key);
+int json_has_key(cJSON* obj, const char* key);
+size_t json_get_bytes(cJSON* obj, const char* key, uint8_t* output, size_t output_size);
+void json_add_bytes(cJSON* obj, const char* key, const uint8_t* data, size_t data_len);
+
+#endif /* JSON_UTILS_H */

--- a/iso15118/shared/cbv2g_wrapper/third_party/cJSON/cJSON.c
+++ b/iso15118/shared/cbv2g_wrapper/third_party/cJSON/cJSON.c
@@ -1,0 +1,3191 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/* cJSON */
+/* JSON parser in C. */
+
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+#include <float.h>
+
+#ifdef ENABLE_LOCALES
+#include <locale.h>
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#include "cJSON.h"
+
+/* define our own boolean type */
+#ifdef true
+#undef true
+#endif
+#define true ((cJSON_bool)1)
+
+#ifdef false
+#undef false
+#endif
+#define false ((cJSON_bool)0)
+
+/* define isnan and isinf for ANSI C, if in C99 or above, isnan and isinf has been defined in math.h */
+#ifndef isinf
+#define isinf(d) (isnan((d - d)) && !isnan(d))
+#endif
+#ifndef isnan
+#define isnan(d) (d != d)
+#endif
+
+#ifndef NAN
+#ifdef _WIN32
+#define NAN sqrt(-1.0)
+#else
+#define NAN 0.0/0.0
+#endif
+#endif
+
+typedef struct {
+    const unsigned char *json;
+    size_t position;
+} error;
+static error global_error = { NULL, 0 };
+
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
+{
+    return (const char*) (global_error.json + global_error.position);
+}
+
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
+{
+    if (!cJSON_IsString(item))
+    {
+        return NULL;
+    }
+
+    return item->valuestring;
+}
+
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
+{
+    if (!cJSON_IsNumber(item))
+    {
+        return (double) NAN;
+    }
+
+    return item->valuedouble;
+}
+
+/* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 19)
+    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+#endif
+
+CJSON_PUBLIC(const char*) cJSON_Version(void)
+{
+    static char version[15];
+    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+
+    return version;
+}
+
+/* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
+static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+{
+    if ((string1 == NULL) || (string2 == NULL))
+    {
+        return 1;
+    }
+
+    if (string1 == string2)
+    {
+        return 0;
+    }
+
+    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++)
+    {
+        if (*string1 == '\0')
+        {
+            return 0;
+        }
+    }
+
+    return tolower(*string1) - tolower(*string2);
+}
+
+typedef struct internal_hooks
+{
+    void *(CJSON_CDECL *allocate)(size_t size);
+    void (CJSON_CDECL *deallocate)(void *pointer);
+    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
+} internal_hooks;
+
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
+static void * CJSON_CDECL internal_malloc(size_t size)
+{
+    return malloc(size);
+}
+static void CJSON_CDECL internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
+
+/* strlen of character literals resolved at compile time */
+#define static_strlen(string_literal) (sizeof(string_literal) - sizeof(""))
+
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
+
+static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
+{
+    size_t length = 0;
+    unsigned char *copy = NULL;
+
+    if (string == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen((const char*)string) + sizeof("");
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    memcpy(copy, string, length);
+
+    return copy;
+}
+
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
+{
+    if (hooks == NULL)
+    {
+        /* Reset hooks */
+        global_hooks.allocate = malloc;
+        global_hooks.deallocate = free;
+        global_hooks.reallocate = realloc;
+        return;
+    }
+
+    global_hooks.allocate = malloc;
+    if (hooks->malloc_fn != NULL)
+    {
+        global_hooks.allocate = hooks->malloc_fn;
+    }
+
+    global_hooks.deallocate = free;
+    if (hooks->free_fn != NULL)
+    {
+        global_hooks.deallocate = hooks->free_fn;
+    }
+
+    /* use realloc only if both free and malloc are used */
+    global_hooks.reallocate = NULL;
+    if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free))
+    {
+        global_hooks.reallocate = realloc;
+    }
+}
+
+/* Internal constructor. */
+static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
+{
+    cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
+    if (node)
+    {
+        memset(node, '\0', sizeof(cJSON));
+    }
+
+    return node;
+}
+
+/* Delete a cJSON structure. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
+{
+    cJSON *next = NULL;
+    while (item != NULL)
+    {
+        next = item->next;
+        if (!(item->type & cJSON_IsReference) && (item->child != NULL))
+        {
+            cJSON_Delete(item->child);
+        }
+        if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
+        {
+            global_hooks.deallocate(item->valuestring);
+            item->valuestring = NULL;
+        }
+        if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+        {
+            global_hooks.deallocate(item->string);
+            item->string = NULL;
+        }
+        global_hooks.deallocate(item);
+        item = next;
+    }
+}
+
+/* get the decimal point character of the current locale */
+static unsigned char get_decimal_point(void)
+{
+#ifdef ENABLE_LOCALES
+    struct lconv *lconv = localeconv();
+    return (unsigned char) lconv->decimal_point[0];
+#else
+    return '.';
+#endif
+}
+
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    internal_hooks hooks;
+} parse_buffer;
+
+/* check if the given size is left to read in a given parse buffer (starting with 1) */
+#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+/* check if the buffer can be accessed at the given index (starting with 0) */
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+/* get a pointer to the buffer at the position */
+#define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
+
+/* Parse the input text to generate a number, and populate the result into item. */
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
+{
+    double number = 0;
+    unsigned char *after_end = NULL;
+    unsigned char *number_c_string;
+    unsigned char decimal_point = get_decimal_point();
+    size_t i = 0;
+    size_t number_string_length = 0;
+    cJSON_bool has_decimal_point = false;
+
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false;
+    }
+
+    /* copy the number into a temporary buffer and replace '.' with the decimal point
+     * of the current locale (for strtod)
+     * This also takes care of '\0' not necessarily being available for marking the end of the input */
+    for (i = 0; can_access_at_index(input_buffer, i); i++)
+    {
+        switch (buffer_at_offset(input_buffer)[i])
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_string_length++;
+                break;
+
+            case '.':
+                number_string_length++;
+                has_decimal_point = true;
+                break;
+
+            default:
+                goto loop_end;
+        }
+    }
+loop_end:
+    /* malloc for temporary buffer, add 1 for '\0' */
+    number_c_string = (unsigned char *) input_buffer->hooks.allocate(number_string_length + 1);
+    if (number_c_string == NULL)
+    {
+        return false; /* allocation failure */
+    }
+
+    memcpy(number_c_string, buffer_at_offset(input_buffer), number_string_length);
+    number_c_string[number_string_length] = '\0';
+
+    if (has_decimal_point)
+    {
+        for (i = 0; i < number_string_length; i++)
+        {
+            if (number_c_string[i] == '.')
+            {
+                /* replace '.' with the decimal point of the current locale (for strtod) */
+                number_c_string[i] = decimal_point;
+            }
+        }
+    }
+
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
+    {
+        /* free the temporary buffer */
+        input_buffer->hooks.deallocate(number_c_string);
+        return false; /* parse_error */
+    }
+
+    item->valuedouble = number;
+
+    /* use saturation in case of overflow */
+    if (number >= INT_MAX)
+    {
+        item->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        item->valueint = INT_MIN;
+    }
+    else
+    {
+        item->valueint = (int)number;
+    }
+
+    item->type = cJSON_Number;
+
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    /* free the temporary buffer */
+    input_buffer->hooks.deallocate(number_c_string);
+    return true;
+}
+
+/* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
+{
+    if (number >= INT_MAX)
+    {
+        object->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        object->valueint = INT_MIN;
+    }
+    else
+    {
+        object->valueint = (int)number;
+    }
+
+    return object->valuedouble = number;
+}
+
+/* Note: when passing a NULL valuestring, cJSON_SetValuestring treats this as an error and return NULL */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
+{
+    char *copy = NULL;
+    size_t v1_len;
+    size_t v2_len;
+    /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted or valuestring is NULL */
+    if (object->valuestring == NULL || valuestring == NULL)
+    {
+        return NULL;
+    }
+
+    v1_len = strlen(valuestring);
+    v2_len = strlen(object->valuestring);
+
+    if (v1_len <= v2_len)
+    {
+        /* strcpy does not handle overlapping string: [X1, X2] [Y1, Y2] => X2 < Y1 or Y2 < X1 */
+        if (!( valuestring + v1_len < object->valuestring || object->valuestring + v2_len < valuestring ))
+        {
+            return NULL;
+        }
+        strcpy(object->valuestring, valuestring);
+        return object->valuestring;
+    }
+    copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    if (object->valuestring != NULL)
+    {
+        cJSON_free(object->valuestring);
+    }
+    object->valuestring = copy;
+
+    return copy;
+}
+
+typedef struct
+{
+    unsigned char *buffer;
+    size_t length;
+    size_t offset;
+    size_t depth; /* current nesting depth (for formatted printing) */
+    cJSON_bool noalloc;
+    cJSON_bool format; /* is this print a formatted print */
+    internal_hooks hooks;
+} printbuffer;
+
+/* realloc printbuffer if necessary to have at least "needed" bytes more */
+static unsigned char* ensure(printbuffer * const p, size_t needed)
+{
+    unsigned char *newbuffer = NULL;
+    size_t newsize = 0;
+
+    if ((p == NULL) || (p->buffer == NULL))
+    {
+        return NULL;
+    }
+
+    if ((p->length > 0) && (p->offset >= p->length))
+    {
+        /* make sure that offset is valid */
+        return NULL;
+    }
+
+    if (needed > INT_MAX)
+    {
+        /* sizes bigger than INT_MAX are currently not supported */
+        return NULL;
+    }
+
+    needed += p->offset + 1;
+    if (needed <= p->length)
+    {
+        return p->buffer + p->offset;
+    }
+
+    if (p->noalloc) {
+        return NULL;
+    }
+
+    /* calculate new buffer size */
+    if (needed > (INT_MAX / 2))
+    {
+        /* overflow of int, use INT_MAX if possible */
+        if (needed <= INT_MAX)
+        {
+            newsize = INT_MAX;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        newsize = needed * 2;
+    }
+
+    if (p->hooks.reallocate != NULL)
+    {
+        /* reallocate with realloc if available */
+        newbuffer = (unsigned char*)p->hooks.reallocate(p->buffer, newsize);
+        if (newbuffer == NULL)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+    }
+    else
+    {
+        /* otherwise reallocate manually */
+        newbuffer = (unsigned char*)p->hooks.allocate(newsize);
+        if (!newbuffer)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+
+        memcpy(newbuffer, p->buffer, p->offset + 1);
+        p->hooks.deallocate(p->buffer);
+    }
+    p->length = newsize;
+    p->buffer = newbuffer;
+
+    return newbuffer + p->offset;
+}
+
+/* calculate the new length of the string in a printbuffer and update the offset */
+static void update_offset(printbuffer * const buffer)
+{
+    const unsigned char *buffer_pointer = NULL;
+    if ((buffer == NULL) || (buffer->buffer == NULL))
+    {
+        return;
+    }
+    buffer_pointer = buffer->buffer + buffer->offset;
+
+    buffer->offset += strlen((const char*)buffer_pointer);
+}
+
+/* securely comparison of floating-point variables */
+static cJSON_bool compare_double(double a, double b)
+{
+    double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return (fabs(a - b) <= maxVal * DBL_EPSILON);
+}
+
+/* Render the number nicely from the given item into a string. */
+static cJSON_bool print_number(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    double d = item->valuedouble;
+    int length = 0;
+    size_t i = 0;
+    unsigned char number_buffer[26] = {0}; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
+    double test = 0.0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* This checks for NaN and Infinity */
+    if (isnan(d) || isinf(d))
+    {
+        length = sprintf((char*)number_buffer, "null");
+    }
+    else if(d == (double)item->valueint)
+    {
+        length = sprintf((char*)number_buffer, "%d", item->valueint);
+    }
+    else
+    {
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+        length = sprintf((char*)number_buffer, "%1.15g", d);
+
+        /* Check whether the original double can be recovered */
+        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        {
+            /* If not, print with 17 decimal places of precision */
+            length = sprintf((char*)number_buffer, "%1.17g", d);
+        }
+    }
+
+    /* sprintf failed or buffer overrun occurred */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
+    {
+        return false;
+    }
+
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    /* copy the printed number to the output and replace locale
+     * dependent decimal point with '.' */
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
+
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
+
+    output_buffer->offset += (size_t)length;
+
+    return true;
+}
+
+/* parse 4 digit hexadecimal number */
+static unsigned parse_hex4(const unsigned char * const input)
+{
+    unsigned int h = 0;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        /* parse digit */
+        if ((input[i] >= '0') && (input[i] <= '9'))
+        {
+            h += (unsigned int) input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F'))
+        {
+            h += (unsigned int) 10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f'))
+        {
+            h += (unsigned int) 10 + input[i] - 'a';
+        }
+        else /* invalid */
+        {
+            return 0;
+        }
+
+        if (i < 3)
+        {
+            /* shift left to make place for the next nibble */
+            h = h << 4;
+        }
+    }
+
+    return h;
+}
+
+/* converts a UTF-16 literal to UTF-8
+ * A literal can be one or two sequences of the form \uXXXX */
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
+{
+    long unsigned int codepoint = 0;
+    unsigned int first_code = 0;
+    const unsigned char *first_sequence = input_pointer;
+    unsigned char utf8_length = 0;
+    unsigned char utf8_position = 0;
+    unsigned char sequence_length = 0;
+    unsigned char first_byte_mark = 0;
+
+    if ((input_end - first_sequence) < 6)
+    {
+        /* input ends unexpectedly */
+        goto fail;
+    }
+
+    /* get the first utf16 sequence */
+    first_code = parse_hex4(first_sequence + 2);
+
+    /* check that the code is valid */
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
+    {
+        goto fail;
+    }
+
+    /* UTF16 surrogate pair */
+    if ((first_code >= 0xD800) && (first_code <= 0xDBFF))
+    {
+        const unsigned char *second_sequence = first_sequence + 6;
+        unsigned int second_code = 0;
+        sequence_length = 12; /* \uXXXX\uXXXX */
+
+        if ((input_end - second_sequence) < 6)
+        {
+            /* input ends unexpectedly */
+            goto fail;
+        }
+
+        if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
+        {
+            /* missing second half of the surrogate pair */
+            goto fail;
+        }
+
+        /* get the second utf16 sequence */
+        second_code = parse_hex4(second_sequence + 2);
+        /* check that the code is valid */
+        if ((second_code < 0xDC00) || (second_code > 0xDFFF))
+        {
+            /* invalid second half of the surrogate pair */
+            goto fail;
+        }
+
+
+        /* calculate the unicode codepoint from the surrogate pair */
+        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else
+    {
+        sequence_length = 6; /* \uXXXX */
+        codepoint = first_code;
+    }
+
+    /* encode as UTF-8
+     * takes at maximum 4 bytes to encode:
+     * 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+    if (codepoint < 0x80)
+    {
+        /* normal ascii, encoding 0xxxxxxx */
+        utf8_length = 1;
+    }
+    else if (codepoint < 0x800)
+    {
+        /* two bytes, encoding 110xxxxx 10xxxxxx */
+        utf8_length = 2;
+        first_byte_mark = 0xC0; /* 11000000 */
+    }
+    else if (codepoint < 0x10000)
+    {
+        /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 3;
+        first_byte_mark = 0xE0; /* 11100000 */
+    }
+    else if (codepoint <= 0x10FFFF)
+    {
+        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 4;
+        first_byte_mark = 0xF0; /* 11110000 */
+    }
+    else
+    {
+        /* invalid unicode codepoint */
+        goto fail;
+    }
+
+    /* encode as utf8 */
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--)
+    {
+        /* 10xxxxxx */
+        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        codepoint >>= 6;
+    }
+    /* encode first byte */
+    if (utf8_length > 1)
+    {
+        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else
+    {
+        (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
+    }
+
+    *output_pointer += utf8_length;
+
+    return sequence_length;
+
+fail:
+    return 0;
+}
+
+/* Parse the input text into an unescaped cinput, and populate item. */
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
+{
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
+    unsigned char *output_pointer = NULL;
+    unsigned char *output = NULL;
+
+    /* not a string */
+    if (buffer_at_offset(input_buffer)[0] != '\"')
+    {
+        goto fail;
+    }
+
+    {
+        /* calculate approximate size of the output (overestimate) */
+        size_t allocation_length = 0;
+        size_t skipped_bytes = 0;
+        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"'))
+        {
+            /* is escape sequence */
+            if (input_end[0] == '\\')
+            {
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                {
+                    /* prevent buffer overflow when last input character is a backslash */
+                    goto fail;
+                }
+                skipped_bytes++;
+                input_end++;
+            }
+            input_end++;
+        }
+        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"'))
+        {
+            goto fail; /* string ended unexpectedly */
+        }
+
+        /* This is at most how much we need for the output */
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
+        output = (unsigned char*)input_buffer->hooks.allocate(allocation_length + sizeof(""));
+        if (output == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+    }
+
+    output_pointer = output;
+    /* loop through the string literal */
+    while (input_pointer < input_end)
+    {
+        if (*input_pointer != '\\')
+        {
+            *output_pointer++ = *input_pointer++;
+        }
+        /* escape sequence */
+        else
+        {
+            unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
+
+            switch (input_pointer[1])
+            {
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
+
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0)
+                    {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
+
+                default:
+                    goto fail;
+            }
+            input_pointer += sequence_length;
+        }
+    }
+
+    /* zero terminate the output */
+    *output_pointer = '\0';
+
+    item->type = cJSON_String;
+    item->valuestring = (char*)output;
+
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (output != NULL)
+    {
+        input_buffer->hooks.deallocate(output);
+        output = NULL;
+    }
+
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
+    }
+
+    return false;
+}
+
+/* Render the cstring provided to an escaped version that can be printed. */
+static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
+{
+    const unsigned char *input_pointer = NULL;
+    unsigned char *output = NULL;
+    unsigned char *output_pointer = NULL;
+    size_t output_length = 0;
+    /* numbers of additional characters needed for escaping */
+    size_t escape_characters = 0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* empty string */
+    if (input == NULL)
+    {
+        output = ensure(output_buffer, sizeof("\"\""));
+        if (output == NULL)
+        {
+            return false;
+        }
+        strcpy((char*)output, "\"\"");
+
+        return true;
+    }
+
+    /* set "flag" to 1 if something needs to be escaped */
+    for (input_pointer = input; *input_pointer; input_pointer++)
+    {
+        switch (*input_pointer)
+        {
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
+        }
+    }
+    output_length = (size_t)(input_pointer - input) + escape_characters;
+
+    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    if (output == NULL)
+    {
+        return false;
+    }
+
+    /* no characters have to be escaped */
+    if (escape_characters == 0)
+    {
+        output[0] = '\"';
+        memcpy(output + 1, input, output_length);
+        output[output_length + 1] = '\"';
+        output[output_length + 2] = '\0';
+
+        return true;
+    }
+
+    output[0] = '\"';
+    output_pointer = output + 1;
+    /* copy the string */
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
+    {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
+        {
+            /* normal character, copy */
+            *output_pointer = *input_pointer;
+        }
+        else
+        {
+            /* character needs to be escaped */
+            *output_pointer++ = '\\';
+            switch (*input_pointer)
+            {
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    output_pointer += 4;
+                    break;
+            }
+        }
+    }
+    output[output_length + 1] = '\"';
+    output[output_length + 2] = '\0';
+
+    return true;
+}
+
+/* Invoke print_string_ptr (which is useful) on an item. */
+static cJSON_bool print_string(const cJSON * const item, printbuffer * const p)
+{
+    return print_string_ptr((unsigned char*)item->valuestring, p);
+}
+
+/* Predeclare these prototypes. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer);
+
+/* Utility to jump whitespace and cr/lf */
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
+
+    if (cannot_access_at_index(buffer, 0))
+    {
+        return buffer;
+    }
+
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
+
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
+
+    return buffer;
+}
+
+/* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
+static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0))
+    {
+        return NULL;
+    }
+
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    {
+        buffer->offset += 3;
+    }
+
+    return buffer;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    size_t buffer_length;
+
+    if (NULL == value)
+    {
+        return NULL;
+    }
+
+    /* Adding null character size due to require_null_terminated. */
+    buffer_length = strlen(value) + sizeof("");
+
+    return cJSON_ParseWithLengthOpts(value, buffer_length, return_parse_end, require_null_terminated);
+}
+
+/* Parse an object - create a new root, and populate. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    cJSON *item = NULL;
+
+    /* reset error position */
+    global_error.json = NULL;
+    global_error.position = 0;
+
+    if (value == NULL || 0 == buffer_length)
+    {
+        goto fail;
+    }
+
+    buffer.content = (const unsigned char*)value;
+    buffer.length = buffer_length;
+    buffer.offset = 0;
+    buffer.hooks = global_hooks;
+
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
+
+    if (!parse_value(item, buffer_skip_whitespace(skip_utf8_bom(&buffer))))
+    {
+        /* parse failure. ep is set. */
+        goto fail;
+    }
+
+    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    if (require_null_terminated)
+    {
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
+        {
+            goto fail;
+        }
+    }
+    if (return_parse_end)
+    {
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+    }
+
+    return item;
+
+fail:
+    if (item != NULL)
+    {
+        cJSON_Delete(item);
+    }
+
+    if (value != NULL)
+    {
+        error local_error;
+        local_error.json = (const unsigned char*)value;
+        local_error.position = 0;
+
+        if (buffer.offset < buffer.length)
+        {
+            local_error.position = buffer.offset;
+        }
+        else if (buffer.length > 0)
+        {
+            local_error.position = buffer.length - 1;
+        }
+
+        if (return_parse_end != NULL)
+        {
+            *return_parse_end = (const char*)local_error.json + local_error.position;
+        }
+
+        global_error = local_error;
+    }
+
+    return NULL;
+}
+
+/* Default options for cJSON_Parse */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
+{
+    return cJSON_ParseWithOpts(value, 0, 0);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length)
+{
+    return cJSON_ParseWithLengthOpts(value, buffer_length, 0, 0);
+}
+
+#define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
+
+static unsigned char *print(const cJSON * const item, cJSON_bool format, const internal_hooks * const hooks)
+{
+    static const size_t default_buffer_size = 256;
+    printbuffer buffer[1];
+    unsigned char *printed = NULL;
+
+    memset(buffer, 0, sizeof(buffer));
+
+    /* create buffer */
+    buffer->buffer = (unsigned char*) hooks->allocate(default_buffer_size);
+    buffer->length = default_buffer_size;
+    buffer->format = format;
+    buffer->hooks = *hooks;
+    if (buffer->buffer == NULL)
+    {
+        goto fail;
+    }
+
+    /* print the value */
+    if (!print_value(item, buffer))
+    {
+        goto fail;
+    }
+    update_offset(buffer);
+
+    /* check if reallocate is available */
+    if (hooks->reallocate != NULL)
+    {
+        printed = (unsigned char*) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+        if (printed == NULL) {
+            goto fail;
+        }
+        buffer->buffer = NULL;
+    }
+    else /* otherwise copy the JSON over to a new buffer */
+    {
+        printed = (unsigned char*) hooks->allocate(buffer->offset + 1);
+        if (printed == NULL)
+        {
+            goto fail;
+        }
+        memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+        printed[buffer->offset] = '\0'; /* just to be sure */
+
+        /* free the buffer */
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    return printed;
+
+fail:
+    if (buffer->buffer != NULL)
+    {
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    if (printed != NULL)
+    {
+        hooks->deallocate(printed);
+        printed = NULL;
+    }
+
+    return NULL;
+}
+
+/* Render a cJSON item/entity/structure to text. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item)
+{
+    return (char*)print(item, true, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
+{
+    return (char*)print(item, false, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if (prebuffer < 0)
+    {
+        return NULL;
+    }
+
+    p.buffer = (unsigned char*)global_hooks.allocate((size_t)prebuffer);
+    if (!p.buffer)
+    {
+        return NULL;
+    }
+
+    p.length = (size_t)prebuffer;
+    p.offset = 0;
+    p.noalloc = false;
+    p.format = fmt;
+    p.hooks = global_hooks;
+
+    if (!print_value(item, &p))
+    {
+        global_hooks.deallocate(p.buffer);
+        p.buffer = NULL;
+        return NULL;
+    }
+
+    return (char*)p.buffer;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if ((length < 0) || (buffer == NULL))
+    {
+        return false;
+    }
+
+    p.buffer = (unsigned char*)buffer;
+    p.length = (size_t)length;
+    p.offset = 0;
+    p.noalloc = true;
+    p.format = format;
+    p.hooks = global_hooks;
+
+    return print_value(item, &p);
+}
+
+/* Parser core - when encountering text, process appropriately. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer)
+{
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false; /* no input */
+    }
+
+    /* parse the different types of values */
+    /* null */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    {
+        item->type = cJSON_NULL;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* false */
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    {
+        item->type = cJSON_False;
+        input_buffer->offset += 5;
+        return true;
+    }
+    /* true */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* string */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
+    {
+        return parse_string(item, input_buffer);
+    }
+    /* number */
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    {
+        return parse_number(item, input_buffer);
+    }
+    /* array */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
+    {
+        return parse_array(item, input_buffer);
+    }
+    /* object */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
+    {
+        return parse_object(item, input_buffer);
+    }
+
+    return false;
+}
+
+/* Render a value to text. */
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output = NULL;
+
+    if ((item == NULL) || (output_buffer == NULL))
+    {
+        return false;
+    }
+
+    switch ((item->type) & 0xFF)
+    {
+        case cJSON_NULL:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "null");
+            return true;
+
+        case cJSON_False:
+            output = ensure(output_buffer, 6);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "false");
+            return true;
+
+        case cJSON_True:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "true");
+            return true;
+
+        case cJSON_Number:
+            return print_number(item, output_buffer);
+
+        case cJSON_Raw:
+        {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL)
+            {
+                return false;
+            }
+
+            raw_length = strlen(item->valuestring) + sizeof("");
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL)
+            {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
+        }
+
+        case cJSON_String:
+            return print_string(item, output_buffer);
+
+        case cJSON_Array:
+            return print_array(item, output_buffer);
+
+        case cJSON_Object:
+            return print_object(item, output_buffer);
+
+        default:
+            return false;
+    }
+}
+
+/* Build an array from input text. */
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* head of the linked list */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (buffer_at_offset(input_buffer)[0] != '[')
+    {
+        /* not an array */
+        goto fail;
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
+    {
+        /* empty array */
+        goto success;
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        /* parse next value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
+    {
+        goto fail; /* expected end of array */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Array;
+    item->child = head;
+
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an array to text */
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_element = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output array. */
+    /* opening square bracket */
+    output_pointer = ensure(output_buffer, 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer = '[';
+    output_buffer->offset++;
+    output_buffer->depth++;
+
+    while (current_element != NULL)
+    {
+        if (!print_value(current_element, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+        if (current_element->next)
+        {
+            length = (size_t) (output_buffer->format ? 2 : 1);
+            output_pointer = ensure(output_buffer, length + 1);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            *output_pointer++ = ',';
+            if(output_buffer->format)
+            {
+                *output_pointer++ = ' ';
+            }
+            *output_pointer = '\0';
+            output_buffer->offset += length;
+        }
+        current_element = current_element->next;
+    }
+
+    output_pointer = ensure(output_buffer, 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    *output_pointer++ = ']';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Build an object from the text. */
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* linked list head */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
+    {
+        goto fail; /* not an object */
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
+    {
+        goto success; /* empty object */
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        if (cannot_access_at_index(input_buffer, 1))
+        {
+            goto fail; /* nothing comes after the comma */
+        }
+
+        /* parse the name of the child */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_string(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse name */
+        }
+        buffer_skip_whitespace(input_buffer);
+
+        /* swap valuestring and string, because we parsed the name */
+        current_item->string = current_item->valuestring;
+        current_item->valuestring = NULL;
+
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
+        {
+            goto fail; /* invalid object */
+        }
+
+        /* parse the value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
+    {
+        goto fail; /* expected end of object */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Object;
+    item->child = head;
+
+    input_buffer->offset++;
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an object to text. */
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_item = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output: */
+    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    output_pointer = ensure(output_buffer, length + 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer++ = '{';
+    output_buffer->depth++;
+    if (output_buffer->format)
+    {
+        *output_pointer++ = '\n';
+    }
+    output_buffer->offset += length;
+
+    while (current_item)
+    {
+        if (output_buffer->format)
+        {
+            size_t i;
+            output_pointer = ensure(output_buffer, output_buffer->depth);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            for (i = 0; i < output_buffer->depth; i++)
+            {
+                *output_pointer++ = '\t';
+            }
+            output_buffer->offset += output_buffer->depth;
+        }
+
+        /* print key */
+        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        length = (size_t) (output_buffer->format ? 2 : 1);
+        output_pointer = ensure(output_buffer, length);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        *output_pointer++ = ':';
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\t';
+        }
+        output_buffer->offset += length;
+
+        /* print value */
+        if (!print_value(current_item, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        /* print comma if not last */
+        length = ((size_t)(output_buffer->format ? 1 : 0) + (size_t)(current_item->next ? 1 : 0));
+        output_pointer = ensure(output_buffer, length + 1);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        if (current_item->next)
+        {
+            *output_pointer++ = ',';
+        }
+
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\n';
+        }
+        *output_pointer = '\0';
+        output_buffer->offset += length;
+
+        current_item = current_item->next;
+    }
+
+    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    if (output_buffer->format)
+    {
+        size_t i;
+        for (i = 0; i < (output_buffer->depth - 1); i++)
+        {
+            *output_pointer++ = '\t';
+        }
+    }
+    *output_pointer++ = '}';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Get Array size/item / object item. */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
+{
+    cJSON *child = NULL;
+    size_t size = 0;
+
+    if (array == NULL)
+    {
+        return 0;
+    }
+
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
+    }
+
+    /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+
+    return (int)size;
+}
+
+static cJSON* get_array_item(const cJSON *array, size_t index)
+{
+    cJSON *current_child = NULL;
+
+    if (array == NULL)
+    {
+        return NULL;
+    }
+
+    current_child = array->child;
+    while ((current_child != NULL) && (index > 0))
+    {
+        index--;
+        current_child = current_child->next;
+    }
+
+    return current_child;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index)
+{
+    if (index < 0)
+    {
+        return NULL;
+    }
+
+    return get_array_item(array, (size_t)index);
+}
+
+static cJSON *get_object_item(const cJSON * const object, const char * const name, const cJSON_bool case_sensitive)
+{
+    cJSON *current_element = NULL;
+
+    if ((object == NULL) || (name == NULL))
+    {
+        return NULL;
+    }
+
+    current_element = object->child;
+    if (case_sensitive)
+    {
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+    else
+    {
+        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
+    }
+
+    return current_element;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, false);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)
+{
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
+}
+
+/* Utility for array list handling. */
+static void suffix_object(cJSON *prev, cJSON *item)
+{
+    prev->next = item;
+    item->prev = prev;
+}
+
+/* Utility for handling references. */
+static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
+{
+    cJSON *reference = NULL;
+    if (item == NULL)
+    {
+        return NULL;
+    }
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
+}
+
+static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
+{
+    cJSON *child = NULL;
+
+    if ((item == NULL) || (array == NULL) || (array == item))
+    {
+        return false;
+    }
+
+    child = array->child;
+    /*
+     * To find the last item in array quickly, we use prev in array
+     */
+    if (child == NULL)
+    {
+        /* list is empty, start new one */
+        array->child = item;
+        item->prev = item;
+        item->next = NULL;
+    }
+    else
+    {
+        /* append to the end */
+        if (child->prev)
+        {
+            suffix_object(child->prev, item);
+            array->child->prev = item;
+        }
+    }
+
+    return true;
+}
+
+/* Add item to array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item)
+{
+    return add_item_to_array(array, item);
+}
+
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic push
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+/* helper function to cast away const */
+static void* cast_away_const(const void* string)
+{
+    return (void*)string;
+}
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic pop
+#endif
+
+
+static cJSON_bool add_item_to_object(cJSON * const object, const char * const string, cJSON * const item, const internal_hooks * const hooks, const cJSON_bool constant_key)
+{
+    char *new_key = NULL;
+    int new_type = cJSON_Invalid;
+
+    if ((object == NULL) || (string == NULL) || (item == NULL) || (object == item))
+    {
+        return false;
+    }
+
+    if (constant_key)
+    {
+        new_key = (char*)cast_away_const(string);
+        new_type = item->type | cJSON_StringIsConst;
+    }
+    else
+    {
+        new_key = (char*)cJSON_strdup((const unsigned char*)string, hooks);
+        if (new_key == NULL)
+        {
+            return false;
+        }
+
+        new_type = item->type & ~cJSON_StringIsConst;
+    }
+
+    if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+    {
+        hooks->deallocate(item->string);
+    }
+
+    item->string = new_key;
+    item->type = new_type;
+
+    return add_item_to_array(object, item);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, false);
+}
+
+/* Add an item to an object with constant string as key */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
+{
+    if (array == NULL)
+    {
+        return false;
+    }
+
+    return add_item_to_array(array, create_reference(item, &global_hooks));
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
+{
+    if ((object == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    return add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
+{
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
+
+    cJSON_Delete(null);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, false))
+    {
+        return true_item;
+    }
+
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, false))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, false))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, false))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
+{
+    if ((parent == NULL) || (item == NULL) || (item != parent->child && item->prev == NULL))
+    {
+        return NULL;
+    }
+
+    if (item != parent->child)
+    {
+        /* not the first element */
+        item->prev->next = item->next;
+    }
+    if (item->next != NULL)
+    {
+        /* not the last element */
+        item->next->prev = item->prev;
+    }
+
+    if (item == parent->child)
+    {
+        /* first element */
+        parent->child = item->next;
+    }
+    else if (item->next == NULL)
+    {
+        /* last element */
+        parent->child->prev = item->prev;
+    }
+
+    /* make sure the detached item doesn't point anywhere anymore */
+    item->prev = NULL;
+    item->next = NULL;
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which)
+{
+    if (which < 0)
+    {
+        return NULL;
+    }
+
+    return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which)
+{
+    cJSON_Delete(cJSON_DetachItemFromArray(array, which));
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItem(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObject(object, string));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
+}
+
+/* Replace array/object items with new ones. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    cJSON *after_inserted = NULL;
+
+    if (which < 0 || newitem == NULL)
+    {
+        return false;
+    }
+
+    after_inserted = get_array_item(array, (size_t)which);
+    if (after_inserted == NULL)
+    {
+        return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && after_inserted->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
+    }
+
+    newitem->next = after_inserted;
+    newitem->prev = after_inserted->prev;
+    after_inserted->prev = newitem;
+    if (after_inserted == array->child)
+    {
+        array->child = newitem;
+    }
+    else
+    {
+        newitem->prev->next = newitem;
+    }
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
+{
+    if ((parent == NULL) || (parent->child == NULL) || (replacement == NULL) || (item == NULL))
+    {
+        return false;
+    }
+
+    if (replacement == item)
+    {
+        return true;
+    }
+
+    replacement->next = item->next;
+    replacement->prev = item->prev;
+
+    if (replacement->next != NULL)
+    {
+        replacement->next->prev = replacement;
+    }
+    if (parent->child == item)
+    {
+        if (parent->child->prev == parent->child)
+        {
+            replacement->prev = replacement;
+        }
+        parent->child = replacement;
+    }
+    else
+    {   /*
+         * To find the last item in array quickly, we use prev in array.
+         * We can't modify the last item's next pointer where this item was the parent's child
+         */
+        if (replacement->prev != NULL)
+        {
+            replacement->prev->next = replacement;
+        }
+        if (replacement->next == NULL)
+        {
+            parent->child->prev = replacement;
+        }
+    }
+
+    item->next = NULL;
+    item->prev = NULL;
+    cJSON_Delete(item);
+
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    if (which < 0)
+    {
+        return false;
+    }
+
+    return cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+}
+
+static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
+{
+    if ((replacement == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    /* replace the name in the replacement */
+    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+    {
+        cJSON_free(replacement->string);
+    }
+    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+    if (replacement->string == NULL)
+    {
+        return false;
+    }
+
+    replacement->type &= ~cJSON_StringIsConst;
+
+    return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, false);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, true);
+}
+
+/* Create basic types: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_NULL;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_True;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = boolean ? cJSON_True : cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Number;
+        item->valuedouble = num;
+
+        /* use saturation in case of overflow */
+        if (num >= INT_MAX)
+        {
+            item->valueint = INT_MAX;
+        }
+        else if (num <= (double)INT_MIN)
+        {
+            item->valueint = INT_MIN;
+        }
+        else
+        {
+            item->valueint = (int)num;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_String;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL)
+    {
+        item->type = cJSON_String | cJSON_IsReference;
+        item->valuestring = (char*)cast_away_const(string);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Object | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child) {
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Array | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Raw;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)raw, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type=cJSON_Array;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item)
+    {
+        item->type = cJSON_Object;
+    }
+
+    return item;
+}
+
+/* Create Arrays: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if (!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber((double)numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (strings == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for (i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateString(strings[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p,n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+/* Duplication */
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse);
+
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
+{
+    return cJSON_Duplicate_rec(item, 0, recurse );
+}
+
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse)
+{
+    cJSON *newitem = NULL;
+    cJSON *child = NULL;
+    cJSON *next = NULL;
+    cJSON *newchild = NULL;
+
+    /* Bail on bad ptr */
+    if (!item)
+    {
+        goto fail;
+    }
+    /* Create new item */
+    newitem = cJSON_New_Item(&global_hooks);
+    if (!newitem)
+    {
+        goto fail;
+    }
+    /* Copy over all vars */
+    newitem->type = item->type & (~cJSON_IsReference);
+    newitem->valueint = item->valueint;
+    newitem->valuedouble = item->valuedouble;
+    if (item->valuestring)
+    {
+        newitem->valuestring = (char*)cJSON_strdup((unsigned char*)item->valuestring, &global_hooks);
+        if (!newitem->valuestring)
+        {
+            goto fail;
+        }
+    }
+    if (item->string)
+    {
+        newitem->string = (item->type&cJSON_StringIsConst) ? item->string : (char*)cJSON_strdup((unsigned char*)item->string, &global_hooks);
+        if (!newitem->string)
+        {
+            goto fail;
+        }
+    }
+    /* If non-recursive, then we're done! */
+    if (!recurse)
+    {
+        return newitem;
+    }
+    /* Walk the ->next chain for the child. */
+    child = item->child;
+    while (child != NULL)
+    {
+        if(depth >= CJSON_CIRCULAR_LIMIT) {
+            goto fail;
+        }
+        newchild = cJSON_Duplicate_rec(child, depth + 1, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if (!newchild)
+        {
+            goto fail;
+        }
+        if (next != NULL)
+        {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+        }
+        else
+        {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+        }
+        child = child->next;
+    }
+    if (newitem && newitem->child)
+    {
+        newitem->child->prev = newchild;
+    }
+
+    return newitem;
+
+fail:
+    if (newitem != NULL)
+    {
+        cJSON_Delete(newitem);
+    }
+
+    return NULL;
+}
+
+static void skip_oneline_comment(char **input)
+{
+    *input += static_strlen("//");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if ((*input)[0] == '\n') {
+            *input += static_strlen("\n");
+            return;
+        }
+    }
+}
+
+static void skip_multiline_comment(char **input)
+{
+    *input += static_strlen("/*");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if (((*input)[0] == '*') && ((*input)[1] == '/'))
+        {
+            *input += static_strlen("*/");
+            return;
+        }
+    }
+}
+
+static void minify_string(char **input, char **output) {
+    (*output)[0] = (*input)[0];
+    *input += static_strlen("\"");
+    *output += static_strlen("\"");
+
+
+    for (; (*input)[0] != '\0'; (void)++(*input), ++(*output)) {
+        (*output)[0] = (*input)[0];
+
+        if ((*input)[0] == '\"') {
+            (*output)[0] = '\"';
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+            return;
+        } else if (((*input)[0] == '\\') && ((*input)[1] == '\"')) {
+            (*output)[1] = (*input)[1];
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+        }
+    }
+}
+
+CJSON_PUBLIC(void) cJSON_Minify(char *json)
+{
+    char *into = json;
+
+    if (json == NULL)
+    {
+        return;
+    }
+
+    while (json[0] != '\0')
+    {
+        switch (json[0])
+        {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                json++;
+                break;
+
+            case '/':
+                if (json[1] == '/')
+                {
+                    skip_oneline_comment(&json);
+                }
+                else if (json[1] == '*')
+                {
+                    skip_multiline_comment(&json);
+                } else {
+                    json++;
+                }
+                break;
+
+            case '\"':
+                minify_string(&json, (char**)&into);
+                break;
+
+            default:
+                into[0] = json[0];
+                json++;
+                into++;
+        }
+    }
+
+    /* and null-terminate. */
+    *into = '\0';
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Invalid;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_False;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xff) == cJSON_True;
+}
+
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & (cJSON_True | cJSON_False)) != 0;
+}
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_NULL;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Number;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_String;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Array;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Object;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Raw;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+{
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)))
+    {
+        return false;
+    }
+
+    /* check if type is valid */
+    switch (a->type & 0xFF)
+    {
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+        case cJSON_Number:
+        case cJSON_String:
+        case cJSON_Raw:
+        case cJSON_Array:
+        case cJSON_Object:
+            break;
+
+        default:
+            return false;
+    }
+
+    /* identical objects are equal */
+    if (a == b)
+    {
+        return true;
+    }
+
+    switch (a->type & 0xFF)
+    {
+        /* in these cases and equal type is enough */
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+            return true;
+
+        case cJSON_Number:
+            if (compare_double(a->valuedouble, b->valuedouble))
+            {
+                return true;
+            }
+            return false;
+
+        case cJSON_String:
+        case cJSON_Raw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL))
+            {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0)
+            {
+                return true;
+            }
+
+            return false;
+
+        case cJSON_Array:
+        {
+            cJSON *a_element = a->child;
+            cJSON *b_element = b->child;
+
+            for (; (a_element != NULL) && (b_element != NULL);)
+            {
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
+
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
+
+            return true;
+        }
+
+        case cJSON_Object:
+        {
+            cJSON *a_element = NULL;
+            cJSON *b_element = NULL;
+            cJSON_ArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element = get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            cJSON_ArrayForEach(b_element, b)
+            {
+                a_element = get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(b_element, a_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        default:
+            return false;
+    }
+}
+
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size)
+{
+    return global_hooks.allocate(size);
+}
+
+CJSON_PUBLIC(void) cJSON_free(void *object)
+{
+    global_hooks.deallocate(object);
+    object = NULL;
+}

--- a/iso15118/shared/cbv2g_wrapper/third_party/cJSON/cJSON.h
+++ b/iso15118/shared/cbv2g_wrapper/third_party/cJSON/cJSON.h
@@ -1,0 +1,306 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#ifndef cJSON__h
+#define cJSON__h
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#define __WINDOWS__
+#endif
+
+#ifdef __WINDOWS__
+
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
+
+CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
+CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
+CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+
+For *nix builds that support visibility attribute, you can define similar behavior by
+
+setting default visibility to hidden by adding
+-fvisibility=hidden (for gcc)
+or
+-xldscope=hidden (for sun cc)
+to CFLAGS
+
+then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
+
+*/
+
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
+/* export symbols by default, this is necessary for copy pasting the C and header file */
+#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_EXPORT_SYMBOLS
+#endif
+
+#if defined(CJSON_HIDE_SYMBOLS)
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
+#elif defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#elif defined(CJSON_IMPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#endif
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#else
+#define CJSON_PUBLIC(type) type
+#endif
+#endif
+
+/* project version */
+#define CJSON_VERSION_MAJOR 1
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 19
+
+#include <stddef.h>
+
+/* cJSON Types: */
+#define cJSON_Invalid (0)
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw    (1 << 7) /* raw json */
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+/* The cJSON structure: */
+typedef struct cJSON
+{
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+
+typedef struct cJSON_Hooks
+{
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
+} cJSON_Hooks;
+
+typedef int cJSON_bool;
+
+/* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_NESTING_LIMIT
+#define CJSON_NESTING_LIMIT 1000
+#endif
+
+/* Limits the length of circular references can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_CIRCULAR_LIMIT
+#define CJSON_CIRCULAR_LIMIT 10000
+#endif
+
+/* returns the version of cJSON as a string */
+CJSON_PUBLIC(const char*) cJSON_Version(void);
+
+/* Supply malloc, realloc and free functions to cJSON */
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks);
+
+/* Memory Management: the caller is always responsible to free the results from all variants of cJSON_Parse (with cJSON_Delete) and cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
+/* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated);
+
+/* Render a cJSON entity to text for transfer/storage. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+/* Render a cJSON entity to text for transfer/storage without any formatting. */
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
+/* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
+/* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
+/* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+/* Delete a cJSON entity and all subentities. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
+
+/* Returns the number of items in an array (or object). */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
+/* Get item "string" from object. Case insensitive. */
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
+
+/* Check item type and return its value */
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+
+/* These functions check the type of an item */
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item);
+
+/* These calls create a cJSON item of the appropriate type. */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
+/* raw json */
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
+
+/* Create a string where valuestring references a string so
+ * it will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
+
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
+
+/* Append item to the specified array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
+/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
+ * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * writing to `item->string` */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
+/* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
+
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
+
+/* Update array items. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
+
+/* Duplicate a cJSON item */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
+/* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
+/* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
+ * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
+
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant, 
+ * but should point to a readable and writable address area. */
+CJSON_PUBLIC(void) cJSON_Minify(char *json);
+
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+
+/* When assigning an integer value, it needs to be propagated to valuedouble too. */
+#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+/* helper for the cJSON_SetNumberValue macro */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+/* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+
+/* If the object is not a boolean type this does nothing and returns cJSON_Invalid else it returns the new type*/
+#define cJSON_SetBoolValue(object, boolValue) ( \
+    (object != NULL && ((object)->type & (cJSON_False|cJSON_True))) ? \
+    (object)->type=((object)->type &(~(cJSON_False|cJSON_True)))|((boolValue)?cJSON_True:cJSON_False) : \
+    cJSON_Invalid\
+)
+
+/* Macro for iterating over an array or object */
+#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+
+/* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size);
+CJSON_PUBLIC(void) cJSON_free(void *object);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

This PR adds a native C shared library (`libcbv2g_json_wrapper`) that wraps libcbv2g with a JSON-based API for EXI encoding/decoding, designed to replace the Java-based EXIficient codec in Josev's EV simulation stack.

**This is the first of 5 PRs** to upstream the native EXI codec — it establishes the architecture with the smallest protocol (AppHandshake) for early review and feedback.

**Developed by the [Enteligent](https://enteligent.com) Team.**

### Problem

The current EV-side simulation (PyEvJosev) depends on a closed-source Java JAR (`ExiCodec.jar`) for EXI encoding/decoding, which:
- Cannot be extended for new protocols (e.g., ACDP) — [EVerest#118](https://github.com/EVerest/EVerest/issues/118)
- Has 250ms latency per EXI conversion — [iso15118#157](https://github.com/EcoG-io/iso15118/issues/157)
- Fails to build on Yocto/embedded targets — [everest-demo#129](https://github.com/EVerest/everest-demo/issues/129)
- Leaks Java processes per session — [ext-switchev-iso15118#56](https://github.com/EVerest/ext-switchev-iso15118/pull/56)

### What's included (PR 1 of 5)

- \`cbv2g_json_wrapper.h\` — Public API, error codes, namespace constants
- \`cbv2g_json_wrapper.c\` — Protocol dispatch, version/error functions
- \`json_utils.c/.h\` — Shared JSON helpers (base64, hex, accessors)
- \`apphand_converter.c\` — AppHandshake (SAP) protocol converter
- \`converters.h\` — Internal converter declarations
- \`CMakeLists.txt\` — Build system supporting both system-installed libcbv2g (Yocto) and source-tree builds
- Bundled cJSON 1.7.19 (MIT) in \`third_party/\`

### Upcoming PRs

| PR | Content | ~Lines |
|----|---------|--------|
| **1 (this)** | Core + AppHandshake | ~750 |
| 2 | DIN 70121 converter | ~1,274 |
| 3 | ISO 15118-2 converter | ~1,476 |
| 4 | ISO 15118-20 converter | ~1,851 |
| 5 | Python bindings + integration | ~250 |

### Build & Test

\`\`\`bash
# With system-installed libcbv2g (e.g., Yocto)
cmake -S iso15118/shared/cbv2g_wrapper -B build
cmake --build build

# With libcbv2g source tree
cmake -S iso15118/shared/cbv2g_wrapper -B build -DLIBCBV2G_ROOT=/path/to/libcbv2g
cmake --build build
\`\`\`

## Test plan

- [ ] Verify CMake configuration succeeds with system libcbv2g
- [ ] Verify CMake configuration succeeds with source-tree libcbv2g
- [ ] Verify library builds and links correctly
- [ ] Verify AppHandshake encode/decode round-trip
- [ ] Review API surface for suitability before adding more converters

🤖 Generated with [Claude Code](https://claude.com/claude-code)