### PR TITLE
Fix ISO 15118-20 precharge handling

### DIFF
--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -1667,7 +1667,7 @@ class DCPreCharge(StateEVCC):
 
     def __init__(self, comm_session: EVCCCommunicationSession):
         super().__init__(comm_session, Timeouts.DC_PRE_CHARGE_REQ)
-        self.pre_charge_finished_message_built_once = False
+        self.precharge_finished = False
 
     async def process_message(
         self,
@@ -1685,37 +1685,42 @@ class DCPreCharge(StateEVCC):
             return
 
         precharge_res: DCPreChargeRes = cast(DCPreChargeRes, msg)
-        next_state = None
-        if (
-            await self.comm_session.ev_controller.is_precharged(
-                precharge_res.evse_present_voltage
-            )
-            and self.pre_charge_finished_message_built_once
-        ):
-            next_state = PowerDelivery
+
+        ev_controller = self.comm_session.ev_controller
+        is_precharged = await ev_controller.is_precharged(precharge_res.evse_present_voltage)
+
+        if is_precharged and self.precharge_finished:
+            self.comm_session.ongoing_timer = -1
             next_request = await self.build_power_delivery_req()
-            payload_type = ISOV20PayloadTypes.MAINSTREAM
-            namespace = Namespace.ISO_V20_COMMON_MSG
-            timeout = Timeouts.POWER_DELIVERY_REQ
 
             EVEREST_CTX.publish('dc_power_on', None)
 
-        else:
-            next_request = await self.build_pre_charge_message(
-                precharge_res.evse_present_voltage
+            self.create_next_message(
+                PowerDelivery,
+                next_request,
+                Timeouts.POWER_DELIVERY_REQ,
+                Namespace.ISO_V20_COMMON_MSG,
+                ISOV20PayloadTypes.MAINSTREAM,
             )
-            payload_type = ISOV20PayloadTypes.DC_MAINSTREAM
-            timeout = Timeouts.DC_PRE_CHARGE_REQ
-            namespace = Namespace.ISO_V20_DC
-            self.pre_charge_finished_message_built_once = True
+        else:
+            logger.debug("EVSE is still precharging")
+            if self.comm_session.ongoing_timer >= 0:
+                elapsed_time = time.time() - self.comm_session.ongoing_timer
+                if elapsed_time > Timeouts.V2G_EVCC_PRE_CHARGE_TIMEOUT:
+                    self.stop_state_machine("Timeout triggered during Precharge")
+                    return
+            else:
+                self.comm_session.ongoing_timer = time.time()
 
-        self.create_next_message(
-            next_state,
-            next_request,
-            timeout,
-            namespace,
-            payload_type,
-        )
+            next_request = await self.build_pre_charge_message(is_precharged)
+
+            self.create_next_message(
+                DCPreCharge,
+                next_request,
+                Timeouts.DC_PRE_CHARGE_REQ,
+                Namespace.ISO_V20_DC,
+                ISOV20PayloadTypes.MAINSTREAM,
+            )
 
     async def build_power_delivery_req(self):
         if self.comm_session.control_mode == ControlMode.SCHEDULED:
@@ -1765,14 +1770,12 @@ class DCPreCharge(StateEVCC):
         )
         return power_delivery_req
 
-    async def build_pre_charge_message(self, evse_voltage: RationalNumber):
+    async def build_pre_charge_message(self, is_precharged: bool):
         present_voltage = await self.comm_session.ev_controller.get_present_voltage()
-        is_precharged = await self.comm_session.ev_controller.is_precharged(
-            evse_voltage
-        )
         processing = Processing.ONGOING
         if is_precharged:
             processing = Processing.FINISHED
+            self.precharge_finished = True
         dc_pre_charge_req = DCPreChargeReq(
             header=MessageHeader(
                 session_id=self.comm_session.session_id,


### PR DESCRIPTION
This commit correctly handles EV precharge handling by only generating a power delivery request after the EV has precharged AND a precharge request has been sent with EV processing marked as FINISHED.

## Describe your changes

With the current logic, the transition from precharge to the power delivery state is gated by whether the bus is precharged, and whether `pre_charge_finished_message_built_once` is true. The problem is that `pre_charge_finished_message_built_once` is set regardless of whether the bus is precharged, which could cause an issue if the precharge voltage is achieved before the EV finishes processing.

## Issue ticket number and link

N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

Tested with an EVSE that keeps its present voltage at 0V until it detects it has reached requested precharge voltage. 