### PR TITLE
Fix minor error in script comment (documented default password)

### DIFF
--- a/iso15118/shared/pki/create_certs.sh
+++ b/iso15118/shared/pki/create_certs.sh
@@ -64,7 +64,7 @@ usage() {
     You need to provide the ISO 15118 version with the '-v' flag, choosing between the
     two admissible options stated above.
 
-    This script uses by default a password value of 12345, which can be modified
+    This script uses by default a password value of 123456, which can be modified
     if -p option is used as exemplified above.
 
     NOTE: This script will create the following folder structure, if not already


### PR DESCRIPTION
The default password in the EVerest branch was changed to '123456' (from 12345) but the help documentation was not changed.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

