### PR TITLE
Add native cbv2g EXI codec with fall-through to Java EXIficient

### DIFF
--- a/iso15118/secc/main.py
+++ b/iso15118/secc/main.py
@@ -5,6 +5,7 @@ from iso15118.secc import SECCHandler
 from iso15118.secc.controller.interface import ServiceStatus
 from iso15118.secc.controller.simulator import SimEVSEController
 from iso15118.secc.secc_settings import Config
+from iso15118.shared.cbv2g_exi_codec import Cbv2gEXICodec
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 
 logger = logging.getLogger(__name__)
@@ -19,10 +20,19 @@ async def main():
     config.load_envs()
     config.print_settings()
 
+    # Prefer the native cbv2g codec (no Java required); fall back to the
+    # Java-based ExificientEXICodec if the native shared library is missing.
+    try:
+        exi_codec = Cbv2gEXICodec()
+    except Exception as native_err:
+        logger.warning("Native Cbv2gEXICodec unavailable (%s); using ExificientEXICodec",
+                       native_err)
+        exi_codec = ExificientEXICodec()
+
     sim_evse_controller = SimEVSEController()
     await sim_evse_controller.set_status(ServiceStatus.STARTING)
     await SECCHandler(
-        exi_codec=ExificientEXICodec(),
+        exi_codec=exi_codec,
         evse_controller=sim_evse_controller,
         config=config,
     ).start(config.iface)

--- a/iso15118/shared/cbv2g_exi_codec.py
+++ b/iso15118/shared/cbv2g_exi_codec.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Pionix GmbH and Contributors to EVerest
+"""Python ctypes bindings for libcbv2g_json_wrapper."""
+
+import ctypes
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from iso15118.shared.iexi_codec import IEXICodec
+
+logger = logging.getLogger(__name__)
+
+
+class Cbv2gEXICodec(IEXICodec):
+    # Native EXI codec backed by libcbv2g via ctypes.
+
+    # Default buffer sizes
+    ENCODE_BUFFER_SIZE = 65536  # 64KB for encoded EXI
+    DECODE_BUFFER_SIZE = 262144  # 256KB for decoded JSON
+
+    def __init__(self, library_path: Optional[str] = None):
+        """Load libcbv2g_json_wrapper.so and bind the C entry points."""
+        self._lib = None
+        self._library_path = library_path or self._find_library()
+
+        if self._library_path is None:
+            raise RuntimeError(
+                "Could not find libcbv2g_json_wrapper.so. "
+                "Please build the library first or specify the path."
+            )
+
+        self._load_library()
+        self._setup_functions()
+        logger.info(f"Cbv2gEXICodec initialized with library: {self._library_path}")
+
+    def _find_library(self) -> Optional[str]:
+        """Locate libcbv2g_json_wrapper.so in standard or LD_LIBRARY_PATH locations."""
+        lib_name = "libcbv2g_json_wrapper.so"
+
+        # Possible search paths
+        search_paths = [
+            # Relative to this file
+            Path(__file__).parent / "cbv2g_wrapper" / "build" / lib_name,
+            Path(__file__).parent / "cbv2g_wrapper" / "build" / "lib" / lib_name,
+            # Standard locations
+            Path("/usr/local/lib") / lib_name,
+            Path("/usr/lib") / lib_name,
+            # Current directory
+            Path.cwd() / lib_name,
+            Path.cwd() / "build" / lib_name,
+        ]
+
+        # Add LD_LIBRARY_PATH directories
+        ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+        for path in ld_library_path.split(":"):
+            if path:
+                search_paths.append(Path(path) / lib_name)
+
+        # Search for the library
+        for path in search_paths:
+            if path.exists():
+                return str(path)
+
+        return None
+
+    def _load_library(self) -> None:
+        """Load the shared library via ctypes."""
+        try:
+            self._lib = ctypes.CDLL(self._library_path)
+        except OSError as e:
+            raise RuntimeError(
+                f"Failed to load libcbv2g_json_wrapper.so from {self._library_path}: {e}"
+            )
+
+    def _setup_functions(self) -> None:
+        """Bind argtypes and restypes for the C entry points."""
+        # cbv2g_encode
+        self._lib.cbv2g_encode.argtypes = [
+            ctypes.c_char_p,  # json_message
+            ctypes.c_char_p,  # namespace
+            ctypes.POINTER(ctypes.c_uint8),  # output_buffer
+            ctypes.c_size_t,  # buffer_size
+            ctypes.POINTER(ctypes.c_size_t),  # output_length
+        ]
+        self._lib.cbv2g_encode.restype = ctypes.c_int
+
+        # cbv2g_decode
+        self._lib.cbv2g_decode.argtypes = [
+            ctypes.POINTER(ctypes.c_uint8),  # exi_data
+            ctypes.c_size_t,  # exi_length
+            ctypes.c_char_p,  # namespace
+            ctypes.c_char_p,  # output_json
+            ctypes.c_size_t,  # buffer_size
+        ]
+        self._lib.cbv2g_decode.restype = ctypes.c_int
+
+        # cbv2g_get_version
+        self._lib.cbv2g_get_version.argtypes = []
+        self._lib.cbv2g_get_version.restype = ctypes.c_char_p
+
+        # cbv2g_get_last_error
+        self._lib.cbv2g_get_last_error.argtypes = []
+        self._lib.cbv2g_get_last_error.restype = ctypes.c_char_p
+
+        # cbv2g_clear_error
+        self._lib.cbv2g_clear_error.argtypes = []
+        self._lib.cbv2g_clear_error.restype = None
+
+    def encode(self, message: str, namespace: str) -> bytes:
+        """Encode a JSON message to EXI bytes for the given V2G namespace."""
+        # Create output buffer
+        output_buffer = (ctypes.c_uint8 * self.ENCODE_BUFFER_SIZE)()
+        output_length = ctypes.c_size_t()
+
+        # Call the C function
+        result = self._lib.cbv2g_encode(
+            message.encode("utf-8"),
+            namespace.encode("utf-8"),
+            output_buffer,
+            self.ENCODE_BUFFER_SIZE,
+            ctypes.byref(output_length),
+        )
+
+        if result != 0:
+            error_msg = self._lib.cbv2g_get_last_error()
+            error_str = error_msg.decode("utf-8") if error_msg else "Unknown error"
+            raise Exception(f"EXI encoding failed (code {result}): {error_str}")
+
+        # Return the encoded bytes
+        return bytes(output_buffer[: output_length.value])
+
+    def decode(self, stream: bytes, namespace: str) -> str:
+        """Decode EXI bytes to a JSON message for the given V2G namespace."""
+        # Create input buffer from stream
+        exi_data = (ctypes.c_uint8 * len(stream))(*stream)
+
+        # Create output buffer
+        output_buffer = ctypes.create_string_buffer(self.DECODE_BUFFER_SIZE)
+
+        # Call the C function
+        result = self._lib.cbv2g_decode(
+            exi_data,
+            len(stream),
+            namespace.encode("utf-8"),
+            output_buffer,
+            self.DECODE_BUFFER_SIZE,
+        )
+
+        if result != 0:
+            error_msg = self._lib.cbv2g_get_last_error()
+            error_str = error_msg.decode("utf-8") if error_msg else "Unknown error"
+            raise Exception(f"EXI decoding failed (code {result}): {error_str}")
+
+        # Return the decoded JSON string
+        return output_buffer.value.decode("utf-8")
+
+    def get_version(self) -> str:
+        """Return the libcbv2g_json_wrapper version string."""
+        version = self._lib.cbv2g_get_version()
+        return version.decode("utf-8") if version else "unknown"
+
+    def shutdown(self) -> None:
+        """No Java gateway to tear down; the native codec has no session-end work."""

--- a/iso15118/shared/exi_codec.py
+++ b/iso15118/shared/exi_codec.py
@@ -10,6 +10,7 @@ from iso15118.shared.exceptions import (
     EXIEncodingError,
     V2GMessageValidationError,
 )
+from iso15118.shared.cbv2g_exi_codec import Cbv2gEXICodec
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 from iso15118.shared.iexi_codec import IEXICodec
 from iso15118.shared.messages import BaseModel
@@ -182,7 +183,15 @@ class EXI:
         If exi_codec is not specified return an instance of the default codec Exificient
         """
         if self.exi_codec is None:
-            self.exi_codec = ExificientEXICodec()
+            try:
+                self.exi_codec = Cbv2gEXICodec()
+                logger.info("Using native Cbv2gEXICodec (no Java required)")
+            except Exception as native_err:
+                logger.warning(
+                    "Native Cbv2gEXICodec unavailable (%s); "
+                    "falling back to ExificientEXICodec", native_err,
+                )
+                self.exi_codec = ExificientEXICodec()
         return self.exi_codec
 
     def to_exi(self, msg_element: BaseModel, protocol_ns: str) -> bytes:

--- a/tests/shared/test_cbv2g_codec_fallthrough.py
+++ b/tests/shared/test_cbv2g_codec_fallthrough.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Pionix GmbH and Contributors to EVerest
+"""Tests for the native cbv2g EXI codec fall-through to ExificientEXICodec."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from iso15118.shared.exi_codec import EXI
+from iso15118.shared.exificient_exi_codec import ExificientEXICodec
+
+
+@pytest.fixture(autouse=True)
+def reset_exi_singleton():
+    """EXI is a singleton; reset its codec between tests."""
+    EXI._instance = None
+    yield
+    EXI._instance = None
+
+
+def test_exi_falls_back_to_exificient_when_native_unavailable():
+    """Native codec constructor raises -> ExificientEXICodec is used."""
+    with patch(
+        "iso15118.shared.exi_codec.Cbv2gEXICodec",
+        side_effect=RuntimeError(
+            "Could not find libcbv2g_json_wrapper.so."
+        ),
+    ):
+        codec = EXI().get_exi_codec()
+
+    assert isinstance(codec, ExificientEXICodec), (  # nosec B101
+        "expected ExificientEXICodec fallback when native codec unavailable"
+    )
+
+
+def test_exi_prefers_native_when_available():
+    """When Cbv2gEXICodec constructs cleanly, EXI uses it."""
+
+    class _FakeNative:
+        def encode(self, message, namespace):  # pragma: no cover - not invoked
+            return b""
+
+        def decode(self, stream, namespace):  # pragma: no cover - not invoked
+            return ""
+
+        def get_version(self):
+            return "1.0.0-fake"
+
+    with patch(
+        "iso15118.shared.exi_codec.Cbv2gEXICodec",
+        return_value=_FakeNative(),
+    ):
+        codec = EXI().get_exi_codec()
+
+    assert isinstance(codec, _FakeNative), (  # nosec B101
+        "expected the native codec to be selected when it constructs cleanly"
+    )
+
+
+def test_secc_main_imports_both_codecs():
+    """Static source check that secc/main.py imports both codecs."""
+    main_path = (
+        Path(__file__).resolve().parents[2]
+        / "iso15118"
+        / "secc"
+        / "main.py"
+    )
+    source = main_path.read_text()
+    assert (  # nosec B101
+        "from iso15118.shared.cbv2g_exi_codec import Cbv2gEXICodec" in source
+    ), "secc/main.py must import Cbv2gEXICodec for the runtime fallback"
+    assert (  # nosec B101
+        "from iso15118.shared.exificient_exi_codec import ExificientEXICodec"
+        in source
+    ), "secc/main.py must keep the ExificientEXICodec import for the fallback"
+
+
+def test_explicit_codec_overrides_default():
+    """set_exi_codec() takes precedence over the default selection."""
+
+    class _Sentinel:
+        def encode(self, message, namespace):  # pragma: no cover
+            return b""
+
+        def decode(self, stream, namespace):  # pragma: no cover
+            return ""
+
+        def get_version(self):
+            return "sentinel"
+
+    sentinel = _Sentinel()
+    exi = EXI()
+    exi.set_exi_codec(sentinel)
+    assert exi.get_exi_codec() is sentinel  # nosec B101


### PR DESCRIPTION
## Summary
- Adds the Python ctypes wrapper `Cbv2gEXICodec(IEXICodec)` that loads `libcbv2g_json_wrapper.so` to provide a drop-in replacement for `ExificientEXICodec`.
- Modifies `iso15118/shared/exi_codec.py` so `EXI.get_exi_codec()` prefers the native codec and falls back to `ExificientEXICodec` when the native shared library is unavailable.
- Modifies `iso15118/secc/main.py` to mirror the same fall-through at the SECC entry point.
- Pytest covers native-preferred, Java-fallback, source-static `secc/main.py`-import, and explicit-pass-through selection paths (4 passing locally).

This is the companion to the everest-core PRs introducing `applications/cbv2g_json_wrapper`: EVerest/everest-core#2138 (and stacked siblings).

## Test plan
- [ ] `pytest tests/shared/test_cbv2g_codec_fallthrough.py -v` passes.
- [ ] EV simulator launches with the native codec selected (log line `Using native Cbv2gEXICodec`).
- [ ] Removing `libcbv2g_json_wrapper.so` triggers the fall-back path with a warning.

Refs RFC #58. Supersedes #57.
