### PR TITLE
fix: set die_on_exit to true so that java gateway process is always s…

### DIFF
--- a/iso15118/shared/exificient_exi_codec.py
+++ b/iso15118/shared/exificient_exi_codec.py
@@ -21,7 +21,7 @@ class ExificientEXICodec(IEXICodec):
         logging.getLogger("py4j").setLevel(logging.CRITICAL)
         self.gateway = JavaGateway.launch_gateway(
             classpath=JAR_FILE_PATH,
-            die_on_exit=False,
+            die_on_exit=True,
             javaopts=["--add-opens", "java.base/java.lang=ALL-UNNAMED"],
         )
 


### PR DESCRIPTION
## Describe your changes

This commit https://github.com/EVerest/ext-switchev-iso15118/commit/34d90a4d0173f575fdbdcad7df31f5cf6f119492 changed the `die_on_exit` property of the JavaGateway to false, causing dangling processes in case the PyEvJosev process was killed and/or charging sessions were not properly terminated.

This change reverts the `die_on_exit` but keeps the external shutdown function that is used inside the module.

## Issue ticket number and link

Companion PR: https://github.com/EVerest/EVerest/pull/2146

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

