### PR TITLE
EVCC: fix DCPreCharge finished transition

### DIFF
--- a/iso15118/evcc/comm_session_handler.py
+++ b/iso15118/evcc/comm_session_handler.py
@@ -133,6 +133,10 @@ class EVCCCommunicationSession(V2GCommunicationSession):
         # That value is needed across states (ScheduleExchange and PowerDelivery)
         # (ISO 15118-20)
         self.ev_processing: Processing = Processing.FINISHED
+        # Whether the EVCC has sent a DCPreChargeReq with EVProcessing=Finished.
+        # The EVCC must not advance to PowerDeliveryReq until the SECC has
+        # answered that final DCPreChargeReq.
+        self.dc_precharge_finished_req_sent = False
         # Temporarily save the ScheduleExchangeRes, in case the EVProcessing field of
         # PowerDeliveryReq is set to "Ongoing", so we can access that response in the
         # following PowerDelivery state (ISO 15118-20)

--- a/iso15118/evcc/states/iso15118_20_states.py
+++ b/iso15118/evcc/states/iso15118_20_states.py
@@ -1607,6 +1607,7 @@ class DCCableCheck(StateEVCC):
         if cable_check_res.evse_processing == Processing.FINISHED:
             # Reset the Ongoing timer
             self.comm_session.ongoing_timer = -1
+            self.comm_session.dc_precharge_finished_req_sent = False
             precharge_req = await self.build_pre_charge_message()
             self.create_next_message(
                 DCPreCharge,
@@ -1641,12 +1642,8 @@ class DCCableCheck(StateEVCC):
 
     async def build_pre_charge_message(self):
         present_voltage = await self.comm_session.ev_controller.get_present_voltage()
-        is_precharged = await self.comm_session.ev_controller.is_precharged(
-            RationalNumber(exponent=0, value=0)
-        )
         processing = Processing.ONGOING
-        if is_precharged:
-            processing = Processing.FINISHED
+        self.comm_session.dc_precharge_finished_req_sent = False
         dc_pre_charge_req = DCPreChargeReq(
             header=MessageHeader(
                 session_id=self.comm_session.session_id,
@@ -1667,7 +1664,6 @@ class DCPreCharge(StateEVCC):
 
     def __init__(self, comm_session: EVCCCommunicationSession):
         super().__init__(comm_session, Timeouts.DC_PRE_CHARGE_REQ)
-        self.precharge_finished = False
 
     async def process_message(
         self,
@@ -1689,7 +1685,7 @@ class DCPreCharge(StateEVCC):
         ev_controller = self.comm_session.ev_controller
         is_precharged = await ev_controller.is_precharged(precharge_res.evse_present_voltage)
 
-        if is_precharged and self.precharge_finished:
+        if is_precharged and self.comm_session.dc_precharge_finished_req_sent:
             self.comm_session.ongoing_timer = -1
             next_request = await self.build_power_delivery_req()
 
@@ -1775,7 +1771,9 @@ class DCPreCharge(StateEVCC):
         processing = Processing.ONGOING
         if is_precharged:
             processing = Processing.FINISHED
-            self.precharge_finished = True
+        self.comm_session.dc_precharge_finished_req_sent = (
+            processing == Processing.FINISHED
+        )
         dc_pre_charge_req = DCPreChargeReq(
             header=MessageHeader(
                 session_id=self.comm_session.session_id,


### PR DESCRIPTION
The EV-side DCPreCharge state tracked completion on the state instance, while the first precharge request was created by the preceding cable-check state. This allowed the EVProcessing state to get out of sync and let PowerDelivery start without first sending a final DCPreChargeReq with EVProcessing set to Finished.

## Describe your changes
Track the sent Finished precharge request at session scope, reset it when entering DCPreCharge, force the initial precharge request to Ongoing, and only transition to PowerDelivery after the SECC has answered the Finished DCPreChargeReq.

Note: I'm not sure why the previous PRs https://github.com/EVerest/ext-switchev-iso15118/pull/59 and https://github.com/EVerest/ext-switchev-iso15118/pull/60 did not fix this, even though they say so.
## Issue ticket number and link
Related to issue https://github.com/EVerest/EVerest/issues/2305 and PR https://github.com/EVerest/EVerest/pull/2312
Amends or fixes PR https://github.com/EVerest/ext-switchev-iso15118/pull/59
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

